### PR TITLE
make bump_*_packaging checkout the right packaging branch

### DIFF
--- a/bump_deb_packaging
+++ b/bump_deb_packaging
@@ -2,12 +2,12 @@
 
 . settings
 
-REMOTE_BRANCH=deb/$VERSION
+REMOTE_BRANCH=deb/${FOREMAN_VERSION}
 
 cd "$PACKAGING_DIR"
 
 git fetch $PACKAGING_GIT_REMOTE
-git checkout -b deb/release-$FULLVERSION $PACKAGING_GIT_REMOTE/$REMOTE_BRANCH
+git checkout -b deb/release-$PROJECT-$FULLVERSION $PACKAGING_GIT_REMOTE/$REMOTE_BRANCH
 
 scripts/changelog.rb -v ${FULLVERSION/-RC/~rc}-1 -m "$FULLVERSION released" debian/*/*/changelog
 git add debian/*/*/changelog

--- a/bump_rpm_packaging
+++ b/bump_rpm_packaging
@@ -2,12 +2,12 @@
 
 . settings
 
-REMOTE_BRANCH=rpm/$VERSION
+REMOTE_BRANCH=rpm/${FOREMAN_VERSION}
 
 cd "$PACKAGING_DIR"
 
 git fetch $PACKAGING_GIT_REMOTE
-git checkout -b rpm/release-$FULLVERSION $PACKAGING_GIT_REMOTE/$REMOTE_BRANCH
+git checkout -b rpm/release-$PROJECT-$FULLVERSION $PACKAGING_GIT_REMOTE/$REMOTE_BRANCH
 
 for package in $RPM_PACKAGES ; do
 	(


### PR DESCRIPTION
we always branch for FOREMAN_VERSION, even if PROJECT has a different
numbering scheme