### PR TITLE
Prevent generation of a new key when $FULLGPGKEY is set

### DIFF
--- a/generate_gpg
+++ b/generate_gpg
@@ -7,6 +7,12 @@ if [[ -d $KEYDIR ]] ; then
 	exit 1
 fi
 
+if [[ -n $FULLGPGKEY ]] ; then
+	echo "The full GPG key is already set for $VERSION"
+	echo "You need to use import_gpg_private or remove the setting"
+	exit 2
+fi
+
 mkdir -m 0700 $KEYDIR
 
 ( gopass show "$PASS_NAME_GPG" 2> /dev/null || gopass generate "$PASS_NAME_GPG" 20 ) > /dev/null


### PR DESCRIPTION
When $FULLGPGKEY is set in the settings, someone else has already generated a key and uploaded it to the shared storage. Generating a new one can lead to hard to track problems and bad interactions.