### PR TITLE
don't pass --password to gopass when pulling the GPG key

### DIFF
--- a/import_gpg_private
+++ b/import_gpg_private
@@ -7,4 +7,4 @@ if [[ ! -d "$KEYDIR" ]] ; then
 fi
 
 copy_gpg_key
-gopass show --password "$PASS_NAME_KEY" | gpg2 --homedir "$KEYDIR" --import
+gopass show "$PASS_NAME_KEY" | gpg2 --homedir "$KEYDIR" --import


### PR DESCRIPTION
--password returns the first line, but we want the *whole* secret