### PR TITLE
Add a script to control Redmine

### DIFF
--- a/close_redmine_version
+++ b/close_redmine_version
@@ -1,0 +1,7 @@
+#!/bin/bash -e
+
+. settings
+
+if [[ $FULLVERSION != *-rc* ]]; then
+	./redmine version set-status "$PROJECT" "$FULLVERSION" closed
+fi

--- a/redmine
+++ b/redmine
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+
+# pylint: disable=raise-missing-from
+
+import argparse
+import os
+
+try:
+    from redminelib import Redmine
+    from redminelib.exceptions import ValidationError
+except ImportError:
+    raise SystemExit('Failed to require python-redmine')
+
+VERSION_STATES = ('open', 'locked', 'closed')
+
+
+def get_redmine() -> Redmine:
+    try:
+        api_key = os.environ['REDMINE_API_KEY']
+    except KeyError:
+        raise SystemExit('No REDMINE_API_KEY environment variable set')
+
+    return Redmine('https://projects.theforeman.org', key=api_key)
+
+
+def create_version(args: argparse.Namespace) -> None:
+    redmine = get_redmine()
+    try:
+        redmine.version.create(
+            project_id=args.project_id,
+            name=args.name,
+            status=args.status,
+            sharing=args.sharing,
+        )
+    except ValidationError as ex:
+        raise SystemExit(str(ex))
+
+
+def set_status_version(args: argparse.Namespace) -> None:
+    redmine = get_redmine()
+    versions = redmine.version.filter(project_id=args.project_id)
+    try:
+        version = [version for version in versions if version.name == args.name][0]
+    except IndexError:
+        raise SystemExit('Version not found')
+
+    version.save(status=args.status)
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    resource = parser.add_subparsers(title='resource')
+
+    version = resource.add_parser(name='version')
+    version_action = version.add_subparsers(title='action')
+
+    version_create = version_action.add_parser('create')
+    version_create.add_argument('project_id')
+    version_create.add_argument('name')
+    version_create.add_argument('--status', default='open', choices=VERSION_STATES)
+    version_create.add_argument('--sharing', default='descendants',
+            choices=('none', 'descendants', 'hierachy', 'tree', 'system'))
+    version_create.set_defaults(func=create_version)
+
+    version_set_status = version_action.add_parser('set-status')
+    version_set_status.add_argument('project_id')
+    version_set_status.add_argument('name')
+    version_set_status.add_argument('status', default='closed', choices=VERSION_STATES)
+    version_set_status.set_defaults(func=set_status_version)
+
+    args = parser.parse_args()
+    args.func(args)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
For now this is limited to versions.

The close_redmine_version script which does the right thing during the release process.

There is no create_redmine_version script since that requires some calculation of the next version and I didn't want to touch that just yet. The direct redmine script can be used instead.