### PR TITLE
Add a script to wait for packaging to complete

### DIFF
--- a/wait-packaging
+++ b/wait-packaging
@@ -1,0 +1,12 @@
+#!/bin/bash -e
+
+. settings
+
+if [[ $PROJECT == pulpcore ]] ; then
+	./ci-jobs poll "pulpcore-packaging-rpm-${VERSION}-release"
+else
+	./ci-jobs poll "foreman-packaging-deb-${FOREMAN_VERSION}-release" &
+	./ci-jobs poll "foreman-packaging-rpm-${FOREMAN_VERSION}-release" &
+
+	wait
+fi


### PR DESCRIPTION
During the release process there's a step where the release engineer needs to wait for packaging to complete. This uses the existing ci-jobs functionality to poll a job.

This allows a release engineer to script things further, like:

```sh
./wait-packaging && ./download_rpms
```