### PR TITLE
Add a script to show the GPG key to be used for Koji

### DIFF
--- a/koji_show_gpg
+++ b/koji_show_gpg
@@ -1,0 +1,5 @@
+#!/bin/bash -e
+
+. settings
+
+echo "Short GPG key to be used for Koji: ${GPGKEY}"


### PR DESCRIPTION
This value was already calculated to download from Koji. Having a script to print it simplifies writing the mashing scripts.