### PR TITLE
Do not echo Redmine API key & no escape chars

### DIFF
--- a/close_redmine_version
+++ b/close_redmine_version
@@ -4,7 +4,7 @@
 
 if [[ -z $REDMINE_API_KEY ]] ; then
 	echo "No API key set. Get it from https://projects.theforeman.org/my/account"
-	read -p "Redmine API KEY: " REDMINE_API_KEY
+	read -s -r -p "Redmine API KEY: " REDMINE_API_KEY
 	export REDMINE_API_KEY
 fi
 


### PR DESCRIPTION
This turns on silent mode for read, which doesn't echo the (sensitive) value. It also adds -r to avoid treating backslashes as escape characters, which we don't want.