### PR TITLE
Support git worktrees for foreman-packaging

### DIFF
--- a/bump_packaging
+++ b/bump_packaging
@@ -12,7 +12,24 @@ fi
 REMOTE_BRANCH="${FLAVOR}/${FOREMAN_VERSION}"
 FULL_REMOTE_BRANCH="$PACKAGING_GIT_REMOTE/$REMOTE_BRANCH"
 
-cd "$PACKAGING_DIR"
+if [[ $GIT_USE_WORKTREES == true ]] ; then
+	RELEASE_PACKAGING_DIR="${PACKAGING_DIR}/${FLAVOR}-$VERSION"
+
+	if [[ ! -d "$RELEASE_PACKAGING_DIR" ]] ; then
+		(
+			cd "${PACKAGING_DIR}/master"
+			git worktree add "$RELEASE_PACKAGING_DIR" "$PACKAGING_GIT_REMOTE/$REMOTE_BRANCH"
+		)
+	fi
+else
+	RELEASE_PACKAGING_DIR="${PACKAGING_DIR}"
+
+	if [[ ! -d "$RELEASE_PACKAGING_DIR" ]] ; then
+		git clone --quiet -o "$PACKAGING_GIT_REMOTE" https://github.com/theforeman/foreman-packaging "${RELEASE_PACKAGING_DIR}"
+	fi
+fi
+
+cd "$RELEASE_PACKAGING_DIR"
 
 git fetch $PACKAGING_GIT_REMOTE
 git checkout -b "${FLAVOR}/release-$PROJECT-$FULLVERSION" "${FULL_REMOTE_BRANCH}"

--- a/bump_packaging
+++ b/bump_packaging
@@ -25,7 +25,7 @@ else
 	RELEASE_PACKAGING_DIR="${PACKAGING_DIR}"
 
 	if [[ ! -d "$RELEASE_PACKAGING_DIR" ]] ; then
-		git clone --quiet -o "$PACKAGING_GIT_REMOTE" https://github.com/theforeman/foreman-packaging "${RELEASE_PACKAGING_DIR}"
+		git clone --quiet --origin "$PACKAGING_GIT_REMOTE" https://github.com/theforeman/foreman-packaging "${RELEASE_PACKAGING_DIR}"
 	fi
 fi
 

--- a/settings
+++ b/settings
@@ -55,6 +55,7 @@ PASS_NAME_GPG="theforeman/releases/foreman/$FOREMAN_VERSION-gpg"
 PASS_NAME_KEY="theforeman/releases/foreman/$FOREMAN_VERSION-key"
 XARGS_JOBS="-n 20 -P 4"
 GIT_DIR="${GIT_DIR:-$HOME/dev}"
+GIT_USE_WORKTREES=false
 GIT_REMOTE="${GIT_REMOTE:-upstream}"
 GIT_DEVELOP_BRANCH=develop
 GIT_STABLE_BRANCH="${VERSION}-stable"


### PR DESCRIPTION
Previously it was assumed to have something like `~/dev/foreman-packaging` but with git worktrees you can create multiple working directories. I have switched over to:

```console
$ tree -L 1 ~/dev/foreman-packaging
/home/ekohl/dev/foreman-packaging
├── deb-3.1
├── deb-3.2
├── deb-3.3
├── deb-3.4
├── deb-3.5
├── deb-3.6
├── deb-develop
├── master
├── rpm-3.1
├── rpm-3.2
├── rpm-3.3
├── rpm-3.5
├── rpm-3.6
└── rpm-develop
```

This is all backed by a single .git directory, which makes it much cheaper.

It is off by default, but can be enabled with a (local) setting.