### PR TITLE
Print error to stderr

### DIFF
--- a/ensure_clean_git_checkouts
+++ b/ensure_clean_git_checkouts
@@ -16,7 +16,7 @@ for project in $PROJECTS ; do
 		if [[ -d "$project_dir" ]] ; then
 			cd "$project_dir"
 			if ! git diff --quiet --exit-code ; then
-				echo "Checkout in $PWD is dirty"
+				echo "Checkout in $PWD is dirty" >&2
 				exit 1
 			fi
 		else


### PR DESCRIPTION
Otherwise it's swallowed by /dev/null in other scripts.