### PR TITLE
Correct ansible playbook filename

### DIFF
--- a/upload_yum_gpg
+++ b/upload_yum_gpg
@@ -19,7 +19,7 @@ upload() {
 	gpg2 --homedir "$KEYDIR" --armor --export "$FULLGPGKEY" > "$gpg_key"
 
 	copy_unix_pass
-	ansible-playbook --ask-become-pass --inventory=$HOSTS --extra-vars="release=${VERSION} gpg_key=${gpg_key} project=${PROJECT}" upload_rpm_gpg_key.yaml
+	ansible-playbook --ask-become-pass --inventory=$HOSTS --extra-vars="release=${VERSION} gpg_key=${gpg_key} project=${PROJECT}" upload_yum_gpg_public_key.yaml
 }
 
 upload


### PR DESCRIPTION
While writing this I ended up renaming the file for better tab completion, but failed to do so in the wrapper script.

Fixes: 8bb9f0997b499b6ea776f1b73625ebf7c6b4b985 ("Add a script to upload the GPG key to yum.t.o")