### PR TITLE
Correct mash deployment script

### DIFF
--- a/deploy_mash_configs
+++ b/deploy_mash_configs
@@ -4,4 +4,4 @@
 
 ./ensure_clean_git_checkouts tool_belt > /dev/null
 
-scp "${TOOL_BELT}/mash_scripts/${PROJECT}/${VERSION}.0"/*.mash "${KOJI_SSH_TARGET}:/etc/ash/"
+scp "${GIT_DIR}/tool_belt/mash_scripts/${PROJECT}/${VERSION}.0"/*.mash "${KOJI_SSH_TARGET}:/etc/mash/"


### PR DESCRIPTION
An earlier version had $TOOL_BELT defined, but was later refactored to use the ensure_clean_git_checkouts script. It also had a typo in the target.

Fixes: b02a94aa5aad ("Further script the mash config handling")