### PR TITLE
Drop "Ensure stable Pulp release" instruction

### DIFF
--- a/procedures/katello/branch.md.erb
+++ b/procedures/katello/branch.md.erb
@@ -46,9 +46,6 @@
     - [ ] gpg-key: When it becomes available, get the new Foreman GPG key for the corresponding Foreman version ([example here](https://github.com/theforeman/theforeman-rel-eng/blob/master/releases/foreman/2.5/settings) and put the last 8 characters here
     - [ ] tags: update Katello version number in all values.  Check the nightly config to see if any tags/repos need to be updated
   - [ ] Open a PR to [tool_belt](https://github.com/theforeman/tool_belt) with the new config file
-- [ ] Ensure stable Pulp release
-  - [ ] Update the [katello-repos](https://github.com/theforeman/foreman-packaging/blob/rpm/develop/packages/katello/katello-repos/katello-repos.spec#L1-L2)
-  - [ ] Update [forklift](https://github.com/theforeman/forklift/blob/master/roles/katello_repositories/defaults/main.yml#L4-L5)
 - [ ] Coordinate with installer maintainers that expected changes are completed.
   - [ ] [candlepin](https://github.com/theforeman/puppet-candlepin)
   - [ ] [pulpcore](https://github.com/theforeman/puppet-pulpcore)


### PR DESCRIPTION
Step 2 pointed to Pulp 2, rather than Pulp 3 so it was already out of date. For the first part it's incomplete if you want to bump the release. That should happen in nightly anyway and isn't part of branching.