### PR TITLE
Don't gather facts when uploading tarball sigs

### DIFF
--- a/upload_tarball_signatures.yaml
+++ b/upload_tarball_signatures.yaml
@@ -1,6 +1,8 @@
+---
 - hosts: all
   become: true
   become_user: downloads
+  gather_facts: false
   tasks:
     - name: "Upload signatures"
       copy:


### PR DESCRIPTION
The playbook doesn't use any facts, so gathering only slows it down.