### PR TITLE
Fix import GPG keys

### DIFF
--- a/settings
+++ b/settings
@@ -79,7 +79,7 @@ show_gpg_password() {
 }
 
 gpg_with_password() {
-	show_gpg_password | gpg2 --pinentry-mode loopback --passphrase-fd 0 "$@"
+	gpg2 --pinentry-mode loopback --passphrase-file <(show_gpg_password) "$@"
 }
 
 # Invoke ansible-playbook with ansible_become_password set safely


### PR DESCRIPTION
Previously stdin was used for the gpg passphrase, but importing of the private key also happens on stdin. Now it uses a path to a file for the gpg passphrase, which leaves stdin available for the private key.

Fixes: c71e78754308 ("Securely pass the password to GPG")