### PR TITLE
Use explicit rsync options to detect unchanged RPMs when uploading to stagingyum

### DIFF
--- a/upload_stage_rpms
+++ b/upload_stage_rpms
@@ -5,4 +5,4 @@
 USER='yumrepostage'
 HOST='web01.osuosl.theforeman.org'
 
-rsync --archive --verbose --partial --one-file-system --delete-after "tmp/$PROJECT/$VERSION" "$USER@$HOST:rsync_cache/$PROJECT"
+rsync --checksum --perms --recursive --links --verbose --partial --one-file-system --delete-after "tmp/$PROJECT/$VERSION" "$USER@$HOST:rsync_cache/$PROJECT"


### PR DESCRIPTION
I am proposing we use `checksum` to determine if an RPM should get synced to stagingyum.theforeman.org. In the current state, using the default of mtime and size, we download the packages from Copr and they all end up getting synced to stagingyum (and thus to yum.theforeman.org) whether they changed or not.

@evgeni @ekohl This is a follow on to our bigger original discussion around not overriding RPMs in production that have not changed.