### PR TITLE
Set Foreman version in Katello release procedure

### DIFF
--- a/procedure
+++ b/procedure
@@ -89,9 +89,6 @@ procedures = {
     opts.on('--project [PROJECT]', ['foreman', 'katello'],
             'Project to generate release procedure for') do |project|
       context[:project] = project
-      if project == 'katello'
-        context[:foreman_version] = 'FOREMAN_VERSION'
-      end
     end
     opts.on('--version [FULL_VERSION]',
             /^(?<version>(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+))([-.](?<extra>rc\d+))?$/,
@@ -109,6 +106,9 @@ procedures = {
         version: version, # 1.20.0
         short_version_minus_two: "#{major}.#{minor.to_i - 2}"
       )
+    end
+    opts.on('--foreman-version [X.Y]', /^\d+\.\d+$/, 'Foreman version, for Katello') do |foreman_version|
+      context[:foreman_version] = foreman_version
     end
     opts.on('--target-date [YYYY-MM-DD]', Date,
             'Target date that the procedure should be completed on') do |date|
@@ -133,7 +133,7 @@ if procedures.key?(procedure)
   command = procedures[procedure]
   command.order!
 
-  unless context[:project] && context[:target_date] && context[:owner]
+  unless context[:project] && context[:target_date] && context[:owner] && (context[:project] != 'katello' || context[:foreman_version])
     STDERR.puts command.help
     exit 1
   end

--- a/procedure_release
+++ b/procedure_release
@@ -22,4 +22,4 @@ if [[ $READ == 1 ]] ; then
 	echo >&2
 fi
 
-./procedure release --project "$PROJECT" --version "$FULLVERSION" --target-date "$TARGET_DATE" --owner "$OWNER" --engineer "$ENGINEER"
+./procedure release --project "$PROJECT" --version "$FULLVERSION" --foreman-version "$FOREMAN_VERSION" --target-date "$TARGET_DATE" --owner "$OWNER" --engineer "$ENGINEER"

--- a/procedures/katello/release.md.erb
+++ b/procedures/katello/release.md.erb
@@ -23,12 +23,12 @@
 - [ ] Change Redmine version <%= full_version %> state to Closed using <%= rel_eng_script('close_redmine_version') %>
 <% end -%>
 - [ ] Check for outdated deprecation warnings in the current and next release with `./tools check-deprecation-warnings configs/katello/<%= short_version %>.yaml`. Follow the instructions in the output of the command. Don't forget to create any Redmine issues needed!
-- [ ] Update [docs.theforeman.org](https://github.com/theforeman/foreman-documentation)
+- [ ] Update the `<%= foreman_version %>` branch in [foreman-documentation](https://github.com/theforeman/foreman-documentation)
   - Ensure [release notes](https://github.com/theforeman/foreman-documentation/blob/<%= foreman_version %>/guides/doc-Release_Notes/katello.adoc) are correct
     - Headline features: important features with a few sentences description each
     - Upgrade notes: all important notices that users must be aware of before upgrading
     - Deprecations: features that will be removed or changed in a future version
-  - Using [redmine_release_notes](https://github.com/theforeman/foreman-documentation/blob/<%= foreman_version %>/guides/doc-Release_Notes/redmine_release_notes) script (see [README](https://github.com/theforeman/foreman-documentation/blob/<%= short_version %>/guides/doc-Release_Notes/README.md) as well): `./guides/doc-Release_Notes/redmine_release_notes katello <%= version %> > ./guides/doc-Release_Notes/topics/katello-<%= version %>.adoc`
+  - Using [redmine_release_notes](https://github.com/theforeman/foreman-documentation/blob/<%= foreman_version %>/guides/doc-Release_Notes/redmine_release_notes) (see [README](https://github.com/theforeman/foreman-documentation/blob/<%= foreman_version %>/guides/doc-Release_Notes/README.md) as well): `./guides/doc-Release_Notes/redmine_release_notes katello <%= version %> > ./guides/doc-Release_Notes/topics/katello-<%= version %>.adoc`
 <% unless is_rc && !full_version.end_with?('1') -%>
   - Add `topics/katello-<%= version %>.adoc` to `guides/doc-Release_Notes/master.adoc`: `sed '/x.y.z releases here/a include::topics/katello-<%= version %>.adoc[leveloffset=+1]' master.adoc`
 <% end -%>
@@ -62,13 +62,13 @@
 ## Release Engineer
 
 <% if is_first_ga -%>
-- [ ] Wait for Foreman's GA to be packaged and built before proceeding
+- [ ] Wait for Foreman <%= foreman_version %>.0 GA to be packaged and built before proceeding
 <% end -%>
 - [ ] Update release version similar to [here](https://github.com/theforeman/theforeman-rel-eng/commit/2029a9688da00d9c385c3438dd71b594ba5f728e)
 - [ ] Update `katello`, `katello-repos` and `rubygem-katello` 
   - [ ] Use <%= rel_eng_script('bump_rpm_packaging') %>: `PROJECT=katello VERSION=<%= short_version %> ./bump_rpm_packaging`
 - [ ] Merge packaging PR once job is green
-- [ ] Use <%= rel_eng_script('wait_packaging') %> to wait for [Jenkins to build the packages](https://ci.theforeman.org/job/foreman-packaging-rpm-<%= short_version %>-release/) (replace <%= short_version %> with the matching Foreman version)
+- [ ] Use <%= rel_eng_script('wait_packaging') %> to wait for [Jenkins to build the packages](https://ci.theforeman.org/job/foreman-packaging-rpm-<%= foreman_version %>-release/)
 - [ ] <%= rel_eng_script('download_rpms') %>, <%= rel_eng_script('sign_rpms') %>, <%= rel_eng_script('upload_rpm_signatures') %>, <%= rel_eng_script('upload_rpms') %>
 - [ ] Use <%= rel_eng_script('release_pipeline') %> to kick off the [release pipeline](https://ci.theforeman.org/job/katello-<%= short_version %>-rpm-pipeline/)
 
@@ -76,7 +76,7 @@
 ## Release Owner
 
 <% if is_first_ga -%>
-- [ ] Wait for Foreman's GA to be announced before proceeding
+- [ ] Wait for Foreman <%= foreman_version %>.0 GA to be announced before proceeding
 <% end -%>
 - [ ] Confirm response that the build succeeded (or if necessary, do more cherry-picks and version bumps repeating the steps above)
 - [ ] Test the install and upgrade documentation for both the Katello server and smart proxy


### PR DESCRIPTION
Previously this had a placeholder FOREMAN_VERSION, dating back from when it was in tool_belt. Now everything is in the same repository, this can be provided with a correct value.