### PR TITLE
Drop puppet-git from Puppet modules to release

### DIFF
--- a/procedures/foreman/branch.md.erb
+++ b/procedures/foreman/branch.md.erb
@@ -15,7 +15,6 @@
     - [ ] [dhcp](https://github.com/theforeman/puppet-dhcp)
     - [ ] [dns](https://github.com/theforeman/puppet-dns)
     - [ ] [foreman](https://github.com/theforeman/puppet-foreman)
-    - [ ] [git](https://github.com/theforeman/puppet-git)
     - [ ] [pulpcore](https://github.com/theforeman/puppet-pulpcore)
     - [ ] [puppet](https://github.com/theforeman/puppet-puppet)
     - [ ] [puppetserver_foreman](https://github.com/theforeman/puppet-puppetserver_foreman)


### PR DESCRIPTION
This is no longer shipped and instead we rely on puppetlabs-vcsrepo.