### PR TITLE
Upload stage RPMs to target version

### DIFF
--- a/upload_stage_rpms
+++ b/upload_stage_rpms
@@ -5,4 +5,4 @@
 USER='yumrepostage'
 HOST='web01.osuosl.theforeman.org'
 
-rsync --checksum --perms --recursive --links --verbose --partial --one-file-system --delete-after "tmp/$PROJECT/$VERSION" "$USER@$HOST:rsync_cache/$PROJECT"
+rsync --checksum --perms --recursive --links --verbose --partial --one-file-system --delete-after "tmp/$PROJECT/$VERSION/" "$USER@$HOST:rsync_cache/$PROJECT/$VERSION/"


### PR DESCRIPTION
The rsync script on web01 needs the version to exist on the rsync target in order to properly know what release to work with. In order to include the release we need to rsync per OS rather than one command for the whole version.