### PR TITLE
Avoid the need to have git phr as a configured alias

### DIFF
--- a/bump_packaging
+++ b/bump_packaging
@@ -51,7 +51,9 @@ fi
 git commit -m "Release $FULLVERSION"
 
 if [[ $PACKAGING_PR == true ]] ; then
-	git phr -m "Release $FULLVERSION" -b "$REMOTE_BRANCH"
+	# TODO: assumes a remote named whoami for the user's fork
+	git push --set-upstream "$(whoami)" HEAD
+	hub pull-request -m "Release $FULLVERSION" -b "$REMOTE_BRANCH"
 else
 	git push "$PACKAGING_GIT_REMOTE" "HEAD:$REMOTE_BRANCH"
 fi


### PR DESCRIPTION
I'm not 100% sure this is better or worse, but it needs some solution. Either we document the aliases or finish this.

Came up in https://github.com/theforeman/theforeman-rel-eng/issues/336