### PR TITLE
Allow branching katello without foreman_version

### DIFF
--- a/procedure
+++ b/procedure
@@ -133,7 +133,7 @@ if procedures.key?(procedure)
   command = procedures[procedure]
   command.order!
 
-  unless context[:project] && context[:target_date] && context[:owner] && (context[:project] != 'katello' || context[:foreman_version])
+  unless context[:project] && context[:target_date] && context[:owner] && (context[:project] != 'katello' || procedure != 'release' || context[:foreman_version])
     STDERR.puts command.help
     exit 1
   end


### PR DESCRIPTION
This was previously added as a requirement because of the Katello release procedure, but it's not used anywhere in the Katello branching procedure currently, and the too-strict conditional is breaking the command that generates the Katello branching procedure.