### PR TITLE
Use branching date as target_date in branching procedures

### DIFF
--- a/procedures/foreman/branch.md.erb
+++ b/procedures/foreman/branch.md.erb
@@ -121,7 +121,7 @@ The next step should only be done after all branching, including packaging, has 
 ## Release Owner
 
 - [ ] Generate and post the release procedure, if not already posted:
-  - [ ] Use <%= rel_eng_script('procedure_release') %>: `PROJECT=foreman VERSION=<%= release %> ./procedure_release "<%= target_date %>" "<%= owner %>" "<%= engineer %>"
+  - [ ] Use <%= rel_eng_script('procedure_release') %>: `PROJECT=foreman VERSION=<%= release %> ./procedure_release "<%= target_date + 28 %>" "<%= owner %>" "<%= engineer %>"
   - [ ] Post the output in [Development/Releases](https://community.theforeman.org/c/development/releases/20) using `Foreman <%= release %>.0-rc1 release process`
 - [ ] Create the <%= release %>.0-rc release procedure in [Development/Releases](https://community.theforeman.org/c/development/releases/20): `PROJECT=foreman VERSION=<%= release %> ./procedure_release <%= target_date %> '<%= owner %>' '<%= engineer %>' | wl-copy`
 - [ ] Create a `Foreman <%= develop %> Schedule and Planning` post on [Development/Releases](https://community.theforeman.org/c/development/releases/20) using <%= rel_eng_script('schedule') %>: `./schedule <%= target_date + 1 %>` (make sure there are no conflicts with other important dates)

--- a/procedures/katello/branch.md.erb
+++ b/procedures/katello/branch.md.erb
@@ -60,7 +60,7 @@
 - [] Bump Katello related packages to their next versions
   - [] [packaging](https://github.com/theforeman/foreman-packaging/pull/8729/files)
 - [ ] Generate and post the release procedure, if not already posted:
-  - [ ] Use <%= rel_eng_script('procedure_release') %>: `PROJECT=katello VERSION=<%= release %> ./procedure_release "<%= target_date %>" "<%= owner %>" "<%= engineer %>"
+  - [ ] Use <%= rel_eng_script('procedure_release') %>: `PROJECT=katello VERSION=<%= release %> ./procedure_release "<%= target_date + 28 %>" "<%= owner %>" "<%= engineer %>"
   - [ ] Post the output in [Development/Releases](https://community.theforeman.org/c/development/releases/20) using `Katello <%= release %>.0-rc1 release process`
   - [ ] Clone https://github.com/theforeman/apidocs and follow the Katello README section to update the API documentation.
 - [ ] Prepare "Katello Next" and future redmine versions


### PR DESCRIPTION
All procedures currently accept a single target_date. For branching procedures in particular, if the branching date is used as the target_date, this generates correct dates in the section headings but an incorrect date in the command invocation to generate the release procedure. This commit fixes the inconsistency by assuming the branch date is the target_date in branching, and adding four weeks to that date to get the date for GA.