### PR TITLE
Extend PR template after branching docs

### DIFF
--- a/procedures/foreman/branch.md.erb
+++ b/procedures/foreman/branch.md.erb
@@ -88,6 +88,7 @@
 - [ ] Create <%= release %>-stable branches using <%= rel_eng_script('branch_project') %>
 - [ ] Push <%= release %>-stable branches using <%= rel_eng_script('branch_push') %>
 - [ ] Branch foreman-documentation git repository and update website for new release by following the [README instructions](https://github.com/theforeman/foreman-documentation#branching-new-release)
+- [ ] Create a tiny PR in foreman-documentation to add `<%= release %>` to [`.github/PULL_REQUEST_TEMPLATE.md`](https://github.com/theforeman/foreman-documentation/blob/master/.github/PULL_REQUEST_TEMPLATE.md)
 - [ ] Ask Hammer maintainer to branch [hammer-cli](https://github.com/theforeman/hammer-cli) and [hammer-cli-foreman](https://github.com/theforeman/hammer-cli-foreman)
 
 The next step should only be done after all branching, including packaging, has completed.


### PR DESCRIPTION
In "foreman-documentation", there are a lot of open upstream PRs and there is typically a lot of cherry-picking to release branches. When we push the new release branch to foreman-documantation, we should immediately add this as a friendly reminder to a) users opening new PRs and b) maintains that cherry-pick PRs to the PR template.

cc @Griffin-Sullivan 

Related to https://github.com/theforeman/foreman-documentation/pull/2821 and https://github.com/theforeman/foreman-documentation/issues/2820