### PR TITLE
create empty repository when reposync from prod fails

### DIFF
--- a/build_stage_repository
+++ b/build_stage_repository
@@ -159,7 +159,11 @@ def sync_prod_repository(collection, version, target_dir, dist, arch):
             '*.src',
         ])
 
-    check_output(cmd)
+    try:
+        check_output(cmd)
+    except CalledProcessError:
+        print("reposync failed, creating empty repository")
+        create_repository(target_dir)
 
 
 def packages_from_comps(comps):


### PR DESCRIPTION
when there is no prod repo, reposync will fail. this seems to be OK on EL7 and Fedora, but the DNF in EL8 exits non-zero in this case and this interrupts the stage repository building.
just catching this error is not sufficient, as then repodiff will fail on the non-existing repository, so we have to create an empty one.