### PR TITLE
ignore non-available repositories when syncing prod

### DIFF
--- a/build_stage_repository
+++ b/build_stage_repository
@@ -136,6 +136,8 @@ def sync_prod_repository(collection, version, target_dir, dist, arch):
 
     cmd = [
         'dnf',
+        '--config',
+        f'tmp/dnf.conf',
         'reposync',
         '--refresh',
         '--remote-time',
@@ -211,6 +213,8 @@ def copr_repository_urls(repository):
 def compare_repositories(new_repository, old_repository, arch, source=False):
     cmd = [
         'dnf',
+        '--config',
+        f'tmp/dnf.conf',
         'repodiff',
         '--simple',
         '--refresh',
@@ -342,6 +346,9 @@ def main():
 
     if not os.path.exists(srpm_dir):
         os.makedirs(srpm_dir)
+
+    with open(f"{base_dir}/dnf.conf", "w") as dnf_conf:
+        dnf_conf.write("[main]\nskip_if_unavailable=True")
 
     initialize_repository(collection, version, dist, arch, rpm_dir, srpm_dir)
     add_packages_from_copr(collection, version, dist, arch, rpm_dir, srpm_dir, foreman_version)


### PR DESCRIPTION
when there is no prod repo, reposync will fail otherwise. same applies to the repodiff step later.

This is not a problem on EL7 and Fedora, as those set `skip_if_unavailable=True` by default, but EL8+ sets it to `False`.