### PR TITLE
specialcase katello when generating prod repo url

### DIFF
--- a/build_stage_repository
+++ b/build_stage_repository
@@ -191,6 +191,9 @@ def prod_repository(collection, version, dist, arch):
     else:
         subdir = collection.replace('foreman-', '')
 
+    if collection == 'katello':
+        version = f'{version}/katello'
+
     return f"https://yum.theforeman.org/{subdir}/{version}/{dist}/{arch}"
 
 


### PR DESCRIPTION
draft because I don't like it, yet it's needed as otherwise it won't sync prod and re-sign everything