### PR TITLE
Implement a build_stage_repository wrapper

### DIFF
--- a/build_stage_repositories
+++ b/build_stage_repositories
@@ -1,0 +1,7 @@
+#!/bin/bash -e
+
+. settings
+
+for OS in $OSES ; do
+	./build_stage_repository "$PROJECT" "$VERSION" "$OS"
+done


### PR DESCRIPTION
This wraps the logic that is currently in jenkins-jobs. It uses the fact the repository list is already in the settings and then iterates over it.

Currently untested, writing the jenkins-jobs logic that builds on it now.