### PR TITLE
Drop puppet-qpid module from branching procedure

### DIFF
--- a/procedures/foreman/branch.md.erb
+++ b/procedures/foreman/branch.md.erb
@@ -18,7 +18,6 @@
     - [ ] [pulpcore](https://github.com/theforeman/puppet-pulpcore)
     - [ ] [puppet](https://github.com/theforeman/puppet-puppet)
     - [ ] [puppetserver_foreman](https://github.com/theforeman/puppet-puppetserver_foreman)
-    - [ ] [qpid](https://github.com/theforeman/puppet-qpid)
     - [ ] [tftp](https://github.com/theforeman/puppet-tftp)
   - Tier 1 (Dependencies on Tier 0)
     - [ ] [foreman_proxy](https://github.com/theforeman/puppet-foreman_proxy)


### PR DESCRIPTION
This module ahs been dropped and no longer needs to be released.