### PR TITLE
Verify VERSION inside the tarball is correct

### DIFF
--- a/inspect_tarballs
+++ b/inspect_tarballs
@@ -6,6 +6,12 @@ require_fullversion
 
 filenames=()
 for project in $TAR_PROJECTS ; do
-	filenames+=("${TARDIR}/${project}-${FULLVERSION}.tar.bz2")
+	filename="${TARDIR}/${project}-${FULLVERSION}.tar.bz2"
+	filenames+=("$filename")
+	project_version=$(tar xf "$filename" --to-stdout "${project}-${FULLVERSION}/VERSION")
+	if [[ $project_version != "${FULLVERSION}" ]] ; then
+		echo "Incorrect version '${project_version}' in $filename"
+		exit 1
+	fi
 done
 file-roller "${filenames[@]}"


### PR DESCRIPTION
Previously I always did this by hand, but it's rather trivial to verify automatically.

The manual inspection using file-roller is kept in, but arguably there's less need for that now. In the past I've made sure versions were correct (mostly applies to the installer), but the point of this check was always to verify Jenkins built correct tarballs.