### PR TITLE
Correct the order of the code preparation and code tagging steps

### DIFF
--- a/procedures/foreman/release.md.erb
+++ b/procedures/foreman/release.md.erb
@@ -17,14 +17,8 @@
 
 ## Release Owner
 
-<% unless is_rc -%>
-- [ ] Add a new [Redmine version](https://projects.theforeman.org/projects/foreman/settings/versions) for the next minor, unless the series is EOL. Be sure the version is set to sharing with subprojects.
-<% end -%>
 - [ ] Remove/change target version field for any open Redmine tickets assigned to the release still (next minor, unset it or reject)
 - [ ] Ensure that code in git matches issues fixed in <%= full_version %> in redmine. [issues](https://github.com/theforeman/theforeman-rel-eng/blob/master/issues) can be used to generate a comparison between the two.
-<% unless is_rc -%>
-- [ ] Change Redmine version <%= full_version %> state to Closed using <%= rel_eng_script('close_redmine_version') %>
-<% end -%>
 
 # Tagging a release: <%= target_date %>
 
@@ -42,6 +36,10 @@
   - [ ] Create tags using <%= rel_eng_script('tag_project') %>
   - [ ] Push tags using <%= rel_eng_script('tag_push') %>
 - [ ] Run the Jenkins [Tarballs Release](https://ci.theforeman.org/job/tarballs-release/) using <%= rel_eng_script('release_tarballs') %> to create tarballs
+<% unless is_rc -%>
+- [ ] Change Redmine version <%= full_version %> state to Closed using <%= rel_eng_script('close_redmine_version') %>
+- [ ] Add a new [Redmine version](https://projects.theforeman.org/projects/foreman/settings/versions) for the next minor, unless the series is EOL. Be sure the version is set to sharing with subprojects.
+<% end -%>
 
 ## Release Engineer
 

--- a/procedures/foreman/release.md.erb
+++ b/procedures/foreman/release.md.erb
@@ -19,12 +19,12 @@
 
 - [ ] Remove/change target version field for any open Redmine tickets assigned to the release still (next minor, unset it or reject)
 - [ ] Ensure that code in git matches issues fixed in <%= full_version %> in redmine. [issues](https://github.com/theforeman/theforeman-rel-eng/blob/master/issues) can be used to generate a comparison between the two.
+- [ ] Check for open pull requests in [Foreman](https://github.com/theforeman/foreman/pulls?q=is%3Apr+is%3Aopen+branch%3A<%= short_version %>-stable), [smart-proxy](https://github.com/theforeman/smart-proxy/pulls?q=is%3Apr+is%3Aopen+branch%3A<%= short_version %>-stable), [foreman-installer](https://github.com/theforeman/foreman-installer/pulls?q=is%3Apr+is%3Aopen+branch%3A<%= short_version %>-stable) and [foreman-selinux](https://github.com/theforeman/foreman-selinux/pulls?q=is%3Apr+is%3Aopen+branch%3A<%= short_version %>-stable)
 
 # Tagging a release: <%= target_date %>
 
 ## Release Owner
 
-- [ ] Check for open pull requests in [Foreman](https://github.com/theforeman/foreman/pulls?q=is%3Apr+is%3Aopen+branch%3A<%= short_version %>-stable), [smart-proxy](https://github.com/theforeman/smart-proxy/pulls?q=is%3Apr+is%3Aopen+branch%3A<%= short_version %>-stable), [foreman-installer](https://github.com/theforeman/foreman-installer/pulls?q=is%3Apr+is%3Aopen+branch%3A<%= short_version %>-stable) and [foreman-selinux](https://github.com/theforeman/foreman-selinux/pulls?q=is%3Apr+is%3Aopen+branch%3A<%= short_version %>-stable)
 - [ ] Make sure [test_<%= short_version.tr('.', '_') %>_stable](https://ci.theforeman.org/job/test_<%= short_version.tr('.', '_') %>_stable/) and [smart-proxy<%= short_version %>-stable-test](https://ci.theforeman.org/job/smart-proxy-<%= short_version %>-stable-test/) are green using <%= rel_eng_script('verify_green_jobs') %>
 <% if is_rc || is_first_ga -%>
 - [ ] Run `make -C locale tx-update` in foreman <%= short_version %>-stable


### PR DESCRIPTION
Until a release has been tagged, things can still be added and the bot could set the wrong Fixed in Release values. The Redmine steps should be done after.