### PR TITLE
Consistently use prep week

### DIFF
--- a/procedures/katello/branch.md.erb
+++ b/procedures/katello/branch.md.erb
@@ -28,7 +28,7 @@
 
 - [ ] Ensure that issues requiring installer changes are merged
 
-# Two Weeks Prior to Branch Date: <%= two_weeks_before %> to <%= two_weeks_before + 4 %>
+# Prep week: <%= two_weeks_before %> to <%= two_weeks_before + 4 %>
 
 ## Release Owner
 

--- a/schedule
+++ b/schedule
@@ -79,7 +79,7 @@ def main():
         ('Event', 'Date'),
         ('Dev start', dev_start),
         ('Half way point', dev_start + ((branching - dev_start) / 2)),
-        ('Installer module release week', week_range(branching - relativedelta(weeks=2))),
+        ('Prep week', week_range(branching - relativedelta(weeks=2))),
         ('Stabilization week', week_range(branching - relativedelta(weeks=1))),
         ('Branching', branching),
         ('Release Candidate 1', branching),


### PR DESCRIPTION
The week prior to stabilization week is called prep week in Foreman's branching procedure. This aligns the schedule and Katello's branching procedure.