### PR TITLE
Add missing dash in Jenkins job name label

### DIFF
--- a/procedures/foreman/release.md.erb
+++ b/procedures/foreman/release.md.erb
@@ -25,7 +25,7 @@
 
 ## Release Owner
 
-- [ ] Make sure [test_<%= short_version.tr('.', '_') %>_stable](https://ci.theforeman.org/job/test_<%= short_version.tr('.', '_') %>_stable/) and [smart-proxy<%= short_version %>-stable-test](https://ci.theforeman.org/job/smart-proxy-<%= short_version %>-stable-test/) are green using <%= rel_eng_script('verify_green_jobs') %>
+- [ ] Make sure [test_<%= short_version.tr('.', '_') %>_stable](https://ci.theforeman.org/job/test_<%= short_version.tr('.', '_') %>_stable/) and [smart-proxy-<%= short_version %>-stable-test](https://ci.theforeman.org/job/smart-proxy-<%= short_version %>-stable-test/) are green using <%= rel_eng_script('verify_green_jobs') %>
 <% if is_rc || is_first_ga -%>
 - [ ] Run `make -C locale tx-update` in foreman <%= short_version %>-stable
 <% end -%>


### PR DESCRIPTION
Fixes: a3b934beeefe49c2e6fefa5ce8d02b26fc573c03 ("Move procedures from tool_belt to this repo")