### PR TITLE
Restore sign_rpms script, it's used in sign_stage_rpms

### DIFF
--- a/sign_rpms
+++ b/sign_rpms
@@ -1,0 +1,21 @@
+#!/bin/bash -e
+
+. settings
+
+gpg_pass=$(mktemp)
+trap 'shred --remove "${gpg_pass}"' EXIT
+chmod 0700 "$gpg_pass"
+show_gpg_password > "$gpg_pass"
+
+SIGN_FLAGS=(--define "_gpg_sign_cmd_extra_args --pinentry-mode loopback --passphrase-file ${gpg_pass}" --define "_gpg_path $KEYDIR" --define="_gpg_name $SIGNER")
+
+rpmdev-vercmp $(rpm --query --queryformat='%{EVR}' rpm) 4.16.0 || RESULT=$?
+if [[ $RESULT == "11" ]]; then
+	SIGN_FLAGS+=("--rpmv3")
+fi
+
+if [[ -n $1 ]] ; then
+	echo "$@" | xargs $XARGS_JOBS rpmsign --addsign "${SIGN_FLAGS[@]}"
+else
+	find "$RPMDIR" -name '*.rpm' | xargs $XARGS_JOBS rpmsign --addsign "${SIGN_FLAGS[@]}"
+fi


### PR DESCRIPTION
This partially reverts "drop signing scripts that were used with koji"

Fixes: 39674f49ec52ae39a3f44eaa259908defa24641b
