### PR TITLE
Reorder branching steps for installer options

### DIFF
--- a/procedures/foreman/branch.md.erb
+++ b/procedures/foreman/branch.md.erb
@@ -41,13 +41,13 @@
 - [ ] Announce start of stabilization week to discourse [development category](https://community.theforeman.org/c/development).
 - [ ] Request new Hammer CLI release from maintainers if needed.
 - Prepare the manual for the new version:
+  - [ ] Update installer options section of nightly manual using the [get-params script](https://github.com/theforeman/theforeman.org/blob/gh-pages/scripts/installer/get-params)
   - [ ] Copy [website manual content](https://github.com/theforeman/theforeman.org/tree/gh-pages/manuals) from nightly to <%= release %> and update version numbers mentioned in it.
     - `cp -r manuals/nightly manuals/<%= release %>`
     - `cp -r _includes/manuals/nightly _includes/manuals/<%= release %>`
     - `sed -i 's/nightly/<%= release %>/i' manuals/<%= release %>/*.md`
     - `sed -i '/previous_version/ s/: .\+/: "<%= release %>"/' manuals/nightly/index.md`
     - `sed -i '/- nightly/a \ \ - "<%= release %>"' _config.yml`
-  - [ ] Update installer options section of nightly manual using the [get-params script](https://github.com/theforeman/theforeman.org/blob/gh-pages/scripts/installer/get-params)
   - [ ] Clean up deprecation and upgrade warnings from nightly manual for in both [foreman.adoc](https://github.com/theforeman/foreman-documentation/blob/master/guides/doc-Release_Notes/topics/foreman.adoc) and [katello.adoc](https://github.com/theforeman/foreman-documentation/blob/master/guides/doc-Release_Notes/topics/katello.adoc).
 - [ ] Add new languages that are at a [reasonable completion on Transifex](https://www.transifex.com/foreman/foreman/foreman/) to __develop__
 


### PR DESCRIPTION
Reorder the installer options update steps to ensure the updates are done to nightly first so they can be copied to 3.13, instead of having to ensure they are updated in both places.