### PR TITLE
Rely on automated tarball inspection

### DIFF
--- a/inspect_tarballs
+++ b/inspect_tarballs
@@ -14,4 +14,3 @@ for project in $TAR_PROJECTS ; do
 		exit 1
 	fi
 done
-file-roller "${filenames[@]}"


### PR DESCRIPTION
Since ff9ff2628d80f71860c15ce610b343bc8dd6ec4a the tarballs are inspected automatically, which verifies they are valid tar files and not some garbage. By now we can rely on this and no longer need the manual inspection using file-roller.