### PR TITLE
Generate the correct version settings file

### DIFF
--- a/settings
+++ b/settings
@@ -26,7 +26,14 @@ load_settings() {
 # Prepare settings file
 if [[ ! -d "$RELEASEDIR" ]] ; then
 	mkdir -p "$RELEASEDIR"
-	echo "FULLVERSION='${VERSION}.0-rc1'" > "$RELEASEDIR/settings"
+	if [[ $PROJECT == katello ]] ; then
+		echo "FULLVERSION='${VERSION}.0.rc1'" > "$RELEASEDIR/settings"
+	else
+		echo "FULLVERSION='${VERSION}.0-rc1'" > "$RELEASEDIR/settings"
+	fi
+	if [[ $PROJECT != foreman ]] && [[ $FOREMAN_VERSION != "none" ]] ; then
+		echo "FOREMAN_VERSION='${FOREMAN_VERSION}'" >> "$RELEASEDIR/settings"
+	fi
 fi
 
 if [[ $PROJECT != foreman ]]; then


### PR DESCRIPTION
Katello uses dots instead of dashes for RCs. It should also write down the `FOREMAN_VERSION`.

The expected invocation is:

```console
$ PROJECT=katello VERSION=4.17 ./procedure_branch
please set FOREMAN_VERSION in releases/katello/4.17/settings
$ cat releases/katello/4.17/settings
FULLVERSION='4.17.0.rc1'
FOREMAN_VERSION=''
```

Or directly:

```console
$ PROJECT=katello VERSION=4.17 FOREMAN_VERSION=3.15 ./procedure_branch
settings: line 46: releases/foreman/3.15/settings: No such file or directory
$ cat releases/katello/4.17/settings
FULLVERSION='4.17.0.rc1'
FOREMAN_VERSION='3.15'
```