### PR TITLE
Fixes #38398 - Add translation fetch to Katello release procedure

### DIFF
--- a/procedures/katello/branch.md.erb
+++ b/procedures/katello/branch.md.erb
@@ -11,15 +11,14 @@
 - [ ] Update Katello Transifex translations:
   - [ ] Create a Transifex account and join the Foreman team
   - [ ] Spin up a Foreman and Katello installation
-  - [ ] [Configure the Transifex client](https://projects.theforeman.org/projects/foreman/wiki/Translating#How-to-pull-translations)
-  - [ ] [Install grunt](https://github.com/Katello/katello/blob/master/engines/bastion_katello/README.md)
+  - [ ] [Install the Transifex cli client](https://projects.theforeman.org/projects/foreman/wiki/Translating#How-to-pull-translations). Only the first `curl` command is necessary.
+  - [ ] [Install grunt-cli](https://github.com/Katello/katello/blob/master/engines/bastion_katello/README.md)
   - [ ] `grunt i18n:extract` in the katello/engines/bastion_katello directory
-  - [ ] `tx pull --minimum-perc 50 --all` in the katello directory
   - [ ] `make -C locale tx-pull` in the katello directory
   - [ ] `grunt i18n:compile` in the katello/engines/bastion_katello directory
   - [ ] `bundle exec rake plugin:gettext[katello]` in the foreman directory
   - [ ] `bundle exec rake plugin:po_to_json[katello]` in the foreman directory
-  - [ ] `make -C locale commit-translation-files` in the katello directory
+  - [ ] `make -C locale mo-files` in the katello directory
   - [ ] Add any uncommitted translation files and open a PR to Katello (no Redmine issue needed)
 
 # Three Weeks Prior to Branch Date: <%= three_weeks_before %> to <%= three_weeks_before + 4 %>

--- a/procedures/katello/release.md.erb
+++ b/procedures/katello/release.md.erb
@@ -18,6 +18,14 @@
   - [ ] Open a PR in Katello release branch.  Make sure the PR name starts with [CP] to prevent our automations from adding it to Redmine issues.
   - [ ] Using `git cherry-pick -x` as needed, verify tickets in the cherry_picks_<%= full_version %> file are accounted for, or additionally cherry-pick them.  Recommended: Do this in tool_belt's checkout of Katello, in `repos/katello/<%= full_version %>/katello`. This way when you run cherry-picks again, tool_belt will be aware of any picks already completed.
   - [ ] For any cherry-picks that are not needed (including Redmine trackers) you can add them to the `:ignores:` section of `tool_belt` in `configs/katello/<%= short_version %>.yaml`
+- [ ] Update Katello Transifex translations:
+  - [ ] `grunt i18n:extract` in the katello/engines/bastion_katello directory
+  - [ ] `make -C locale tx-pull` in the katello directory
+  - [ ] `grunt i18n:compile` in the katello/engines/bastion_katello directory
+  - [ ] `bundle exec rake plugin:gettext[katello]` in the foreman directory
+  - [ ] `bundle exec rake plugin:po_to_json[katello]` in the foreman directory
+  - [ ] `make -C locale mo-files` in the katello directory
+  - [ ] Add any uncommitted translation files and open a PR to upstream's KATELLO-<%= short_version %> (no Redmine issue needed)
 <% end -%>
 <% unless is_rc -%>
 - [ ] Change Redmine version <%= full_version %> state to Closed using <%= rel_eng_script('close_redmine_version') %>: `PROJECT=katello VERSION=<%= short_version %> ./close_redmine_version` and enter your Redmine API Key when prompted.


### PR DESCRIPTION
When publishing a Katello gem, translations are not pulled from Transifex on releases, just on branching. This means that cherry-picked features completed after branching remain untranslated. Update the release process to include pulling translations.

https://projects.theforeman.org/issues/38398