### PR TITLE
Automate GPG key export with fingerprint and date extraction

### DIFF
--- a/export_gpg_public
+++ b/export_gpg_public
@@ -24,15 +24,22 @@ git -C "$CHECKOUT" checkout -b "add-gpg-key-$VERSION" "$GIT_REMOTE/$TFM_WEBSITE_
 
 gpg2 --homedir "$KEYDIR" --armor --export "$FULLGPGKEY" > "${CHECKOUT}/static/keys/${FULLGPGKEY}.pub"
 
-echo "Fill in any FIXME's and then add this to ${CHECKOUT}/security.md"
-gpg2 --homedir "$KEYDIR" --fingerprint "$FULLGPGKEY"
+read -r CREATION_TS EXPIRATION_TS < <(gpg2 --homedir "$KEYDIR" --with-colons --list-keys "$FULLGPGKEY" | awk -F: '/^pub/{print $6, $7}')
+FINGERPRINT=$(gpg2 --homedir "$KEYDIR" --with-colons --list-keys "$FULLGPGKEY" | awk -F: '/^fpr/{print $10}' | grep -o '....' | xargs printf "%s %s %s %s %s  %s %s %s %s %s")
+echo "Creation Date: $(date -d @"$CREATION_TS" -u +"%Y-%m-%d")"
+echo "Expiration Date: $([ -n "$EXPIRATION_TS" ] && date -d @"$EXPIRATION_TS" -u +"%Y-%m-%d" || echo "Never")"
+echo "Fingerprint: $FINGERPRINT"
+
+echo -e "Add this to ${CHECKOUT}/security.md\n"
+
+
 cat <<EOF
       <tr>
         <td><a href="{{ site.baseurl }}/static/keys/${FULLGPGKEY}.pub">${FULLGPGKEY}</a></td>
-        <td>FIXME: fingerprint</td>
+        <td>${FINGERPRINT}</td>
         <td>${SIGNER_NAME} (${VERSION})</td>
-        <td style='white-space:nowrap'>$(date +%Y-%m-%d)</td>
-        <td style='white-space:nowrap'>FIXME: end date</td>
+        <td style='white-space:nowrap'>$(date -d @"$CREATION_TS" -u +"%Y-%m-%d")</td>
+        <td style='white-space:nowrap'>$([ -n "$EXPIRATION_TS" ] && date -d @"$EXPIRATION_TS" -u +"%Y-%m-%d" || echo "Never")</td>
         <td style='white-space:nowrap'></td>
         <td></td>
       </tr>


### PR DESCRIPTION
## Summary
Automate GPG key information extraction in the `export_gpg_public` script to eliminate manual copy-paste operations.

## Changes
- Parse GPG key fingerprint automatically using `--with-colons` output
- Extract creation and expiration dates from key metadata
- Generate complete security.md table entry with all fields populated
- Remove "FIXME" placeholders that required manual intervention

## Benefits
- Reduces human error from manual copy-paste operations
- Ensures consistent fingerprint formatting (with spaces every 4 characters)
- Automatically handles keys with or without expiration dates

## Testing
- Tested with existing GPG key
- Verified fingerprint formatting matches expected output

Here is the diff of the script output:

```diff
--- <unnamed>
+++ <unnamed>
@@ -1,13 +1,14 @@
-pub   rsa4096 2025-08-07 [SCEAR] [expires: 2026-08-07]
-      4EF0 94BB D6C4 3ADA 8E41  90BD 1835 7B59 AD17 3208
-uid           [ultimate] Foreman Automatic Signing Key (3.16) <packages@theforeman.org>
+Creation Date: 2025-08-07
+Expiration Date: 2026-08-07
+Fingerprint: 4EF0 94BB D6C4 3ADA 8E41  90BD 1835 7B59 AD17 3208
+Add this to /home/ogajduse/repos/theforeman.org/security.md
 
       <tr>
         <td><a href="{{ site.baseurl }}/static/keys/4EF094BBD6C43ADA8E4190BD18357B59AD173208.pub">4EF094BBD6C43ADA8E4190BD18357B59AD173208</a></td>
-        <td>FIXME: fingerprint</td>
+        <td>4EF0 94BB D6C4 3ADA 8E41  90BD 1835 7B59 AD17 3208</td>
         <td>Foreman Automatic Signing Key (3.16)</td>
         <td style='white-space:nowrap'>2025-08-07</td>
-        <td style='white-space:nowrap'>FIXME: end date</td>
+        <td style='white-space:nowrap'>2026-08-07</td>
         <td style='white-space:nowrap'></td>
         <td></td>
       </tr>
```
