### PR TITLE
Use absolute path of the fastly-purge script

### DIFF
--- a/upload_tarball_signatures.yaml
+++ b/upload_tarball_signatures.yaml
@@ -11,5 +11,5 @@
       loop: "{{ files|dict2items }}"
 
     - name: "Invalidate CDN cache"
-      command: "fastly-purge https://downloads.theforeman.org {{ item.value }}"
+      command: "/usr/local/bin/fastly-purge https://downloads.theforeman.org {{ item.value }}"
       loop: "{{ files|dict2items }}"


### PR DESCRIPTION
## Problem Statement

The `fastly-purge` script was not found in `$PATH`.

## Solution

Use full path of the script to ensure Ansible finds it
