### PR TITLE
Improve Git protocol handling and URL consistency

### DIFF
--- a/bump_packaging
+++ b/bump_packaging
@@ -27,7 +27,7 @@ else
 	RELEASE_PACKAGING_DIR="${PACKAGING_DIR}"
 
 	if [[ ! -d "$RELEASE_PACKAGING_DIR" ]] ; then
-		git clone --quiet --origin "$PACKAGING_GIT_REMOTE" https://github.com/theforeman/foreman-packaging "${RELEASE_PACKAGING_DIR}"
+		git clone --quiet --origin "$PACKAGING_GIT_REMOTE" "$(github_url foreman-packaging)" "${RELEASE_PACKAGING_DIR}"
 	fi
 fi
 

--- a/ensure_clean_git_checkouts
+++ b/ensure_clean_git_checkouts
@@ -20,7 +20,7 @@ for repo in $REPOS ; do
 				exit 1
 			fi
 		else
-			git clone --quiet -o "$GIT_REMOTE" "https://github.com/${GITHUB_NAMESPACE}/${repo}" "${project_dir}"
+			git clone --quiet -o "$GIT_REMOTE" "$(github_url "$repo")" "${project_dir}"
 		fi
 	)
 done

--- a/export_gpg_public
+++ b/export_gpg_public
@@ -16,7 +16,7 @@ fi
 CHECKOUT="${GIT_DIR}/theforeman.org"
 
 if [[ ! -d "$CHECKOUT" ]] ; then
-	git clone --quiet --origin "$GIT_REMOTE" https://github.com/theforeman/theforeman.org "$CHECKOUT"
+	git clone --quiet --origin "$GIT_REMOTE" "$(github_url theforeman.org)" "$CHECKOUT"
 fi
 
 git -C "$CHECKOUT" fetch "$GIT_REMOTE"

--- a/settings
+++ b/settings
@@ -68,6 +68,7 @@ XARGS_JOBS="-n 20 -P 4"
 GIT_DIR="${GIT_DIR:-$HOME/dev}"
 GIT_USE_WORKTREES=false
 GIT_REMOTE="${GIT_REMOTE:-upstream}"
+GIT_PROTOCOL="${GIT_PROTOCOL:-https}"
 GIT_DEVELOP_BRANCH=develop
 GIT_STABLE_BRANCH="${VERSION}-stable"
 GITHUB_NAMESPACE=theforeman
@@ -113,6 +114,16 @@ require_fullversion() {
 		echo "FULLVERSION is required for this script"
 		exit 1
 	fi
+}
+
+# Function to construct GitHub URLs based on protocol
+github_url() {
+    local repo="$1"
+    if [[ "$GIT_PROTOCOL" == "ssh" ]]; then
+        echo "git@github.com:${GITHUB_NAMESPACE}/${repo}.git"
+    else
+        echo "https://github.com/${GITHUB_NAMESPACE}/${repo}"
+    fi
 }
 
 # vim: ft=sh


### PR DESCRIPTION
- Add GIT_PROTOCOL setting with https as default in settings
- Add github_url() function to construct URLs based on protocol
- Update scripts to use github_url() for consistent URL handling
- Support both https and ssh protocols for Git operations

This allows users to configure their preferred Git protocol
(https or ssh) and ensures all scripts use consistent URLs.
