### PR TITLE
Improve release engineering scripts and procedures

### DIFF
--- a/branch_project
+++ b/branch_project
@@ -9,6 +9,11 @@ for repo in $(./ensure_clean_git_checkouts "$@") ; do
 		git checkout -b "$GIT_STABLE_BRANCH" "${GIT_REMOTE}/${GIT_DEVELOP_BRANCH}"
 
 		if [[ $repo == foreman-installer ]]; then
+			if ! bundle check &>/dev/null; then
+				echo "Bundle dependencies not installed in foreman-installer" >&2
+				echo "Run: cd $GIT_DIR/$repo && bundle install" >&2
+				exit 1
+			fi
 			bundle exec rake pin_modules
 			sed -i '/Puppetfile.lock/d' .gitignore
 			bundle exec librarian-puppet install

--- a/procedures/foreman/branch.md.erb
+++ b/procedures/foreman/branch.md.erb
@@ -55,6 +55,7 @@
     - `sed -i '/previous_version/ s/: .\+/: "<%= release %>"/' manuals/nightly/index.md`
     - `sed -i '/- nightly/a \ \ - "<%= release %>"' _config.yml`
   - [ ] Clean up deprecation and upgrade warnings from nightly manual for in both [foreman.adoc](https://github.com/theforeman/foreman-documentation/blob/master/guides/doc-Release_Notes/topics/foreman.adoc) and [katello.adoc](https://github.com/theforeman/foreman-documentation/blob/master/guides/doc-Release_Notes/topics/katello.adoc).
+  - [ ] Commit the manual changes: `git commit -a -m "Add Foreman <%= release %> manual and update nightly"` and create a pull request
 - [ ] Add new languages that are at a [reasonable completion on Transifex](https://app.transifex.com/foreman/foreman/foreman/) to __develop__
 
 ## Release Engineer
@@ -68,7 +69,7 @@
   - [ ] Use <%= rel_eng_script('export_gpg_public') %> to show the GPG key and update the website's [security.md](https://github.com/theforeman/theforeman.org/blob/gh-pages/security.md) and create a file in [static/keys](https://github.com/theforeman/theforeman.org/tree/gh-pages/static/keys)
   - [ ] Use <%= rel_eng_script('upload_yum_gpg') %> to create [releases/<%= release %>/RPM-GPG-KEY-foreman](https://yum.theforeman.org/releases/<%= release %>/RPM-GPG-KEY-foreman) on yum.theforeman.org
   - [ ] Make sure the [settings file](https://github.com/theforeman/theforeman-rel-eng/blob/master/releases/foreman/<%= release %>/settings) contains the right `OSES` list. It should match what is in [the nightly settings file](https://github.com/theforeman/theforeman-rel-eng/blob/master/releases/foreman/nightly/settings)
-  - [ ] Commit the [settings file](https://github.com/theforeman/theforeman-rel-eng/blob/master/releases/foreman/<%= release %>/settings) to the `theforeman-rel-eng` repository
+  - [ ] Commit the [settings file](https://github.com/theforeman/theforeman-rel-eng/blob/master/releases/foreman/<%= release %>/settings) to the `theforeman-rel-eng` repository with message: `git commit -m "Foreman <%= release %> settings"`
 - [ ] Create new settings files for [client](https://github.com/theforeman/theforeman-rel-eng/blob/master/releases/client/<%= release %>/settings), ensure it has the rights `OSES` list and commit it too.
 - [ ] Open a PR with the result of [jenkins-jobs](https://github.com/theforeman/jenkins-jobs) branching: `./branch-foreman <%= release %> KATELLO_VERSION`
 - [ ] Open PR to remove any jobs that are related to end of life versions
@@ -116,9 +117,9 @@ The next step should only be done after all branching, including packaging, has 
   - [ ] deb/develop: `scripts/changelog.rb -v <%= develop %>.0-1 -m "Bump changelog to <%= develop %>.0 to match VERSION" debian/*/*/changelog`
 - [ ] Prepare build systems for <%= release %> release:
   - [ ] foreman-packaging's rpm/<%= release %>
-    - [ ] Update `packages/foreman/foreman-release/foreman.gpg`, `mock/*.cfg`, `package_manifest.yaml` and `repoclosure/*.conf`
+    - [ ] Update `packages/foreman/foreman-release/foreman.gpg`, `mock/*.cfg`, `package_manifest.yaml` and `repoclosure/*.conf` and commit with message: `git commit -a -m "Foreman <%= release %> branching build updates"`. See [example patch](https://github.com/theforeman/foreman-packaging/commit/1a70b2ab5c4cfc59bd49d5bf62e3da46dfda39b2)
   - [ ] foreman-packaging's deb/<%= release %>
-    - [ ] Update `debian/*/foreman-release/theforeman-archive-keyring.asc` from https://deb.theforeman.org/foreman.asc, you will only see changes if the key was recently updated.
+    - [ ] Update `debian/*/foreman-release/theforeman-archive-keyring.asc` from https://deb.theforeman.org/foreman.asc, you will only see changes if the key was recently updated, and commit with message: `git commit -a -m "Foreman <%= release %> keyring updates"`
 - [ ] Trigger the [`foreman-packaging-rpm-<%= release %>`](https://ci.theforeman.org/job/foreman-packaging-rpm-<%= release %>-release/) job once, so that GitHub hooks are properly set up.
 - [ ] Trigger the [`foreman-packaging-deb-<%= release %>`](https://ci.theforeman.org/job/foreman-packaging-deb-<%= release %>-release/) job once, so that GitHub hooks are properly set up.
 

--- a/procedures/foreman/release.md.erb
+++ b/procedures/foreman/release.md.erb
@@ -130,7 +130,6 @@ Note: If for some reason there was an issue with the tarballs that required uplo
 <% end -%>
 <% if is_first_rc -%>
 - [ ] Add <%= short_version %> to the navigation in [docs.theforeman.org](https://github.com/theforeman/foreman-documentation) master
-  - `cp web/releases/nightly.adoc web/releases/<%= short_version %>.adoc` and modify as needed
   - `cp web/releases/nightly.json web/releases/<%= short_version %>.json` and modify as needed
 <% elsif is_first_ga -%>
 - [ ] Update the [docs.theforeman.org](https://github.com/theforeman/foreman-documentation) master

--- a/procedures/katello/branch.md.erb
+++ b/procedures/katello/branch.md.erb
@@ -31,7 +31,7 @@
 
 ## Release Owner
 
-- [ ] Commit the [settings file](https://github.com/theforeman/theforeman-rel-eng/blob/master/releases/katello/<%= release %>/settings) to the `theforeman-rel-eng` repository. See an example [here](https://github.com/theforeman/theforeman-rel-eng/commit/29b6b92e82de25c7a0e32fb9ca36468d8df0f6a1)
+- [ ] Commit the [settings file](https://github.com/theforeman/theforeman-rel-eng/blob/master/releases/katello/<%= release %>/settings) to the `theforeman-rel-eng` repository with message: `git commit -m "Katello <%= release %> settings"`. See an example [here](https://github.com/theforeman/theforeman-rel-eng/commit/29b6b92e82de25c7a0e32fb9ca36468d8df0f6a1)
 - [ ] Add tool_belt config for new release:
   - [ ] Create a new yaml file using the nightly Katello config as a template: [tool_belt configs](https://github.com/theforeman/tool_belt/tree/master/configs/katello)
   - [ ] Manually update the following sections:

--- a/release_announcement
+++ b/release_announcement
@@ -8,9 +8,9 @@ ANNOUNCEMENT=$(mktemp)
 trap 'rm -f ${ANNOUNCEMENT}' EXIT
 
 if [[ $FULLVERSION == *-rc* ]] ; then
-	echo "# ${PROJECT} ${FULLVERSION} is now ready for testing" >> "$ANNOUNCEMENT"
+	echo "# ${PROJECT^} ${FULLVERSION} is now ready for testing" >> "$ANNOUNCEMENT"
 else
-	echo "# ${PROJECT} ${FULLVERSION} is now available" >> "$ANNOUNCEMENT"
+	echo "# ${PROJECT^} ${FULLVERSION} is now available" >> "$ANNOUNCEMENT"
 fi
 echo >> "$ANNOUNCEMENT"
 


### PR DESCRIPTION
 - Add bundle install before rake pin_modules in branch_project
 - Fix capitalization in release_announcement (Foreman vs foreman)
 - Add standardized commit messages to procedure templates
 - Add manual commit step to branch procedure for documentation changes
 - Improve Redmine version creation with pre-filled forms
 - Remove reference to deleted file in foreman-documentation: `web/releases/nightly.adoc`

 These changes address issues identified during Foreman 3.16 branching
 to make the release process more reliable and user-friendly.
