### PR TITLE
Add GitHub project management integration to procedures

### DIFF
--- a/procedures/foreman/branch.md.erb
+++ b/procedures/foreman/branch.md.erb
@@ -27,6 +27,10 @@
 
 ## Release Owner
 
+- Setup GitHub project management:
+  - [ ] Create new version field in [Foreman Releases](https://github.com/orgs/theforeman/projects/21/settings/fields/127439092) project: Add "<%= release %>" option to the Version field
+  - [ ] Move the new "<%= release %>" option to the top of the list if it's not already there
+  - [ ] Acknowledge: I will assign all issues and pull requests I create to the [Foreman Releases](https://github.com/orgs/theforeman/projects/21/) project with the correct version
 - [ ] Ensure headline features planned for the release have been merged or push them off to the next release.
 - Translations:
   - [ ] Update locales in foreman __develop__: `make -C locale tx-update`
@@ -53,6 +57,7 @@
 
 ## Release Engineer
 
+- [ ] Acknowledge: I will assign all issues and pull requests I create to the [Foreman Releases](https://github.com/orgs/theforeman/projects/21/) project with the correct version
 - Create new GPG key for release. See [GPG_Keys](https://github.com/theforeman/theforeman-rel-eng/#generating-a-new-gpg-key-for-a-xy-release) if needed.
   - [ ] <%= rel_eng_script('generate_gpg') %>
   - [ ] <%= rel_eng_script('export_gpg_private') %> to back up

--- a/procedures/foreman/release.md.erb
+++ b/procedures/foreman/release.md.erb
@@ -25,6 +25,7 @@
 
 ## Release Owner
 
+- [ ] Acknowledge: I will assign all issues and pull requests I create to the [Foreman Releases](https://github.com/orgs/theforeman/projects/21/) project with the correct version
 - [ ] Make sure [foreman-<%= short_version %>-stable-test](https://ci.theforeman.org/job/foreman-<%= short_version %>-stable-test/) and [smart-proxy-<%= short_version %>-stable-test](https://ci.theforeman.org/job/smart-proxy-<%= short_version %>-stable-test/) are green using <%= rel_eng_script('verify_green_jobs') %>
 <% if is_rc || is_first_ga -%>
 - [ ] Run `make -C locale tx-update` in foreman <%= short_version %>-stable
@@ -43,6 +44,7 @@
 
 ## Release Engineer
 
+- [ ] Acknowledge: I will assign all issues and pull requests I create to the [Foreman Releases](https://github.com/orgs/theforeman/projects/21/) project with the correct version
 - Sign Tarballs
   - [ ] <%= rel_eng_script('download_tarballs') %>
   - [ ] <%= rel_eng_script('inspect_tarballs') %>


### PR DESCRIPTION
## Summary

This PR integrates GitHub project management into the release procedures to improve tracking and organization of release-related work.

## Changes

### Procedure Enhancements
- **GitHub project setup**: Added step-by-step instructions for configuring version fields in the Foreman Releases project
- **Version management**: Clear guidance on adding new release versions and organizing them properly
- **Consistent tracking**: Added project assignment reminders to ensure all issues and PRs are properly tracked
- **Cross-procedure alignment**: Standardized project management expectations across different release phases
- **Accountability reminders**: Added acknowledgment checkboxes for both Release Owner and Release Engineer

### Benefits
- **Better visibility**: All release work will be tracked in a centralized GitHub project
- **Improved organization**: Version-specific filtering and management of release tasks
- **Process standardization**: Consistent approach across all release procedures

This addresses issues encountered during previous releases where tracking release progress was difficult due to scattered issues and PRs across different repositories.