### PR TITLE
Export REDMINE_API_KEY to child processes

### DIFF
--- a/close_redmine_version
+++ b/close_redmine_version
@@ -3,12 +3,11 @@
 . settings
 
 require_fullversion
-
 if [[ -z $REDMINE_API_KEY ]] ; then
 	echo "No API key set. Get it from https://projects.theforeman.org/my/account"
 	read -s -r -p "Redmine API KEY: " REDMINE_API_KEY
-	export REDMINE_API_KEY
 fi
+export REDMINE_API_KEY
 
 if [[ $FULLVERSION != *-rc* ]]; then
 	./redmine version set-status "$PROJECT" "$FULLVERSION" closed


### PR DESCRIPTION
Move the export statement outside the conditional block to ensure REDMINE_API_KEY is exported to child processes regardless of whether it was set in settings.local or entered interactively.

This fixes the issue where the `redmine` script wouldn't receive the API key when it was set in `settings.local`.