### PR TITLE
Revert "use centos-stream chroots for EL10 repos"

### DIFF
--- a/build_stage_repository
+++ b/build_stage_repository
@@ -197,11 +197,7 @@ def packages_from_comps(comps):
 
 
 def copr_repository(collection, version, dist, arch):
-    if dist == 'el10':
-        chroot = 'centos-stream'
-    else:
-        chroot = 'rhel'
-    return f"https://download.copr.fedorainfracloud.org/results/@theforeman/{collection}-{version}-staging/{chroot}-{dist.replace('el', '')}-{arch}"
+    return f"https://download.copr.fedorainfracloud.org/results/@theforeman/{collection}-{version}-staging/rhel-{dist.replace('el', '')}-{arch}"
 
 
 def prod_repository(collection, version, dist, arch):


### PR DESCRIPTION
Change client chroots from CentOS Stream to RHEL

Related to changes in theforeman/foreman-packaging#12767


This reverts commit 8713256e5e4da1102710f39db168599101040207.
