### PR TITLE
Be specific about the file mode of the RPM signing key

### DIFF
--- a/upload_yum_gpg_public_key.yaml
+++ b/upload_yum_gpg_public_key.yaml
@@ -17,3 +17,4 @@
       copy:
         src: "{{ gpg_key }}"
         dest: "{{ releasedir }}/{{ release }}/RPM-GPG-KEY-{{ project }}"
+        mode: '0644'


### PR DESCRIPTION
This patch prevents the signing key to be uploaded with incorrect
permissions.

Keys of the past releases have the following mode set:
```
-rw-r--r--. 1 yumrepo yumrepo 1700 May 20  2024 /var/www/vhosts/yum/htdocs/releases/3.11/RPM-GPG-KEY-foreman
-rw-r--r--. 1 yumrepo yumrepo 1700 Aug 16  2024 /var/www/vhosts/yum/htdocs/releases/3.12/RPM-GPG-KEY-foreman
-rw-r--r--. 1 yumrepo yumrepo 1700 Nov  5  2024 /var/www/vhosts/yum/htdocs/releases/3.13/RPM-GPG-KEY-foreman
-rw----r--. 1 yumrepo yumrepo 1700 Feb 13  2025 /var/www/vhosts/yum/htdocs/releases/3.14/RPM-GPG-KEY-foreman
-rw----r--. 1 yumrepo yumrepo 1700 May 12  2025 /var/www/vhosts/yum/htdocs/releases/3.15/RPM-GPG-KEY-foreman
-rw----r--. 1 yumrepo yumrepo 1700 Aug  8 12:27 /var/www/vhosts/yum/htdocs/releases/3.16/RPM-GPG-KEY-foreman
-rw----r--. 1 yumrepo yumrepo 1700 Jan 14 13:35 /var/www/vhosts/yum/htdocs/releases/3.17/RPM-GPG-KEY-foreman
```
