### PR TITLE
Prevent third-party GPG signatures in release keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,12 +189,17 @@ PROJECT=katello VERSION=3.13 ./generate_stage_repository
 When starting a new release, the following scripts can be used to generate a new key:
 
 ```bash
-generate_gpg
-export_gpg_private
-export_gpg_public
-sign_gpg
-upload_gpg
+generate_gpg           # Generate new GPG key in isolated keydir
+export_gpg_private     # Backup private key to gopass
+export_gpg_public      # Export clean public key for website
+sign_gpg               # Sign key for web-of-trust
+upload_gpg             # Upload to keyserver
 ```
+
+**IMPORTANT:** The published key must contain only the self-signature. Third-party signatures break RPM imports. See [community discussion](https://community.theforeman.org/t/unable-to-register-an-almalinux-8-client-into-foreman-3-17-server-key-import-failed-code-2-failing-package-is-katello-host-tools-4-5-0-2-el8-noarch/45374) for technical details.
+
+**About `sign_gpg`:**
+The `sign_gpg` script is for web-of-trust use only. It exports the key to your main GPG keyring and allows signing with your personal key. The signed version must **never** be re-imported to the isolated keydir. Both `export_gpg_private` and `export_gpg_public` include automatic verification to prevent accidentally exporting keys with third-party signatures.
 
 ### Generating a new GPG Key for signing the Debian repository
 

--- a/export_gpg_private
+++ b/export_gpg_private
@@ -13,6 +13,9 @@ if [[ -z $FULLGPGKEY ]] ; then
 	exit 2
 fi
 
+# Verify key has no third-party signatures
+./verify_gpg_clean || exit $?
+
 if [[ $1 == "force" ]] ; then
 	FORCE="--force"
 else

--- a/export_gpg_public
+++ b/export_gpg_public
@@ -13,6 +13,9 @@ if [[ -z $FULLGPGKEY ]] ; then
 	exit 2
 fi
 
+# Verify key has no third-party signatures
+./verify_gpg_clean || exit $?
+
 CHECKOUT="${GIT_DIR}/theforeman.org"
 
 if [[ ! -d "$CHECKOUT" ]] ; then

--- a/procedures/foreman/branch.md.erb
+++ b/procedures/foreman/branch.md.erb
@@ -61,12 +61,13 @@
 
 - Create new GPG key for release. See [GPG_Keys](https://github.com/theforeman/theforeman-rel-eng/#generating-a-new-gpg-key-for-a-xy-release) if needed.
   - [ ] <%= rel_eng_script('generate_gpg') %>
-  - [ ] <%= rel_eng_script('export_gpg_private') %> to back up
-  - [ ] <%= rel_eng_script('sign_gpg') %>
-  - [ ] <%= rel_eng_script('upload_gpg') %>
+  - [ ] <%= rel_eng_script('export_gpg_private') %> to backup private key to gopass
 - Publish the key
-  - [ ] Use <%= rel_eng_script('export_gpg_public') %> to show the GPG key and update the website's [security.md](https://github.com/theforeman/theforeman.org/blob/gh-pages/security.md) and create a file in [static/keys](https://github.com/theforeman/theforeman.org/tree/gh-pages/static/keys)
+  - [ ] Use <%= rel_eng_script('export_gpg_public') %> to export the clean GPG key and update the website's [security.md](https://github.com/theforeman/theforeman.org/blob/gh-pages/security.md) and create a file in [static/keys](https://github.com/theforeman/theforeman.org/tree/gh-pages/static/keys)
   - [ ] Use <%= rel_eng_script('upload_yum_gpg') %> to create [releases/<%= release %>/RPM-GPG-KEY-foreman](https://yum.theforeman.org/releases/<%= release %>/RPM-GPG-KEY-foreman) on yum.theforeman.org
+- Sign and upload the key to the keyserver
+  - [ ] <%= rel_eng_script('sign_gpg') %> for web-of-trust only - do NOT re-import or back up the signed key
+  - [ ] <%= rel_eng_script('upload_gpg') %> to upload the public key to keyservers
   - [ ] Make sure the [settings file](https://github.com/theforeman/theforeman-rel-eng/blob/master/releases/foreman/<%= release %>/settings) contains the right `OSES` list. It should match what is in [the nightly settings file](https://github.com/theforeman/theforeman-rel-eng/blob/master/releases/foreman/nightly/settings)
   - [ ] Commit the [settings file](https://github.com/theforeman/theforeman-rel-eng/blob/master/releases/foreman/<%= release %>/settings) to the `theforeman-rel-eng` repository
 - [ ] Create new settings files for [client](https://github.com/theforeman/theforeman-rel-eng/blob/master/releases/client/<%= release %>/settings), ensure it has the rights `OSES` list and commit it too.

--- a/verify_gpg_clean
+++ b/verify_gpg_clean
@@ -1,0 +1,34 @@
+#!/bin/bash -e
+
+. settings
+
+if [[ ! -d $KEYDIR ]] ; then
+	echo "ERROR: Keydir $KEYDIR doesn't exist" >&2
+	exit 1
+fi
+
+if [[ -z $FULLGPGKEY ]] ; then
+	echo "ERROR: FULLGPGKEY must be set" >&2
+	gpg2 --homedir "$KEYDIR" --list-key "$SIGNER" >&2
+	exit 2
+fi
+
+SIG_COUNT=$(gpg2 --homedir "$KEYDIR" --list-sigs --with-colons "$FULLGPGKEY" 2>/dev/null | grep -c "^sig:")
+
+if [[ "$SIG_COUNT" -ne 1 ]]; then
+	cat >&2 <<OUTER_EOF
+ERROR: Key has third-party signatures ($SIG_COUNT found, expected 1)
+
+$(gpg2 --homedir "$KEYDIR" --list-sigs "$FULLGPGKEY")
+
+Third-party signatures break RHEL/EL8 RPM imports.
+See: https://community.theforeman.org/t/unable-to-register-an-almalinux-8-client-into-foreman-3-17-server-key-import-failed-code-2-failing-package-is-katello-host-tools-4-5-0-2-el8-noarch/45374
+
+To fix, run:
+  gpg2 --homedir "$KEYDIR" --batch --yes --command-fd 0 --edit-key "$FULLGPGKEY" <<EOF
+clean
+save
+EOF
+OUTER_EOF
+	exit 1
+fi


### PR DESCRIPTION
Add safeguards to prevent third-party signatures from being included in
published GPG keys, which break RPM imports on EL 8.

Changes:
- Add verify_gpg_clean script to check for third-party signatures
- Update export_gpg_private to verify key before backup
- Update export_gpg_public to verify key before export
- Document that sign_gpg is for web-of-trust only
- Reorder branch procedure to publish key before signing
- Add warnings about not re-importing signed keys

Third-party signatures (from web-of-trust signing) cause RHEL/EL8's
RPM parser to fail with "Key import failed (code 2)". The
verification prevents accidentally exporting or backing up keys with
these signatures.

Fixes: #544
