### PR TITLE
Import client signing key before signing the client packages

### DIFF
--- a/procedures/foreman/release.md.erb
+++ b/procedures/foreman/release.md.erb
@@ -72,6 +72,7 @@ Note: If for some reason there was an issue with the tarballs that required uplo
   - [ ] <%= rel_eng_script('sign_stage_rpms') %>
   - [ ] <%= rel_eng_script('upload_stage_rpms') %>
 - Sign RPMs for client repos (call scripts with `PROJECT=client`)
+  - Import the client sigining key if not imported already `PROJECT=client VERSION=<%= short_version %> ./import_gpg_private`
   - [ ] <%= rel_eng_script('generate_stage_repository') %>
   - [ ] <%= rel_eng_script('sign_stage_rpms') %>
   - [ ] <%= rel_eng_script('upload_stage_rpms') %>


### PR DESCRIPTION
Release engineer hits an error if they do not have the signing key
imported. This instructs the release engineer to import it before
signing.

I hit that with every release I did and every time I had to go to my personal notes. Therefore here is a patch to add it to the instruction list for release.
