### PR TITLE
Fix week_range to calculate Friday instead of Saturday

### DIFF
--- a/schedule
+++ b/schedule
@@ -38,7 +38,7 @@ def week_range(day: date) -> str:
     """
     weekday = day.weekday()
     monday = day - relativedelta(days=weekday)
-    friday = day + relativedelta(days=5 - weekday)
+    friday = day + relativedelta(days=4 - weekday)
     return f'{monday} - {friday}'
 
 


### PR DESCRIPTION
The week_range function was using (5 - weekday) which calculated
Saturday instead of Friday. Change to (4 - weekday) to correctly
calculate Friday for Monday-Friday work weeks.
