### PR TITLE
Calculate week ranges correctly as Monday-Friday

### DIFF
--- a/procedure
+++ b/procedure
@@ -53,6 +53,18 @@ def discourse_username(name)
   name.start_with?('@') ? name : "@#{name}"
 end
 
+def week_range(day)
+  # Accept a date and return the Monday - Friday dates in that week
+  # NOTE: This logic is duplicated in schedule script (Python version)
+  # If you change this, update schedule:week_range() to match
+  # Ruby's wday: 0=Sunday, 1=Monday, ..., 6=Saturday
+  # Convert to: 0=Monday, 1=Tuesday, ..., 6=Sunday
+  weekday = (day.wday - 1) % 7
+  monday = day - weekday
+  friday = day + (4 - weekday)
+  { monday: monday, friday: friday }
+end
+
 context = {}
 
 global = OptionParser.new do |opts|
@@ -76,8 +88,16 @@ procedures = {
       context[:target_date] = date
       context[:four_weeks_before] = date - 28
       context[:three_weeks_before] = date - 21
-      context[:two_weeks_before] = date - 14
-      context[:one_week_before] = date - 7
+      two_weeks_before = date - 14
+      one_week_before = date - 7
+      prep_week = week_range(two_weeks_before)
+      stabilization_week = week_range(one_week_before)
+      context[:two_weeks_before] = two_weeks_before
+      context[:one_week_before] = one_week_before
+      context[:prep_week_start] = prep_week[:monday]
+      context[:prep_week_end] = prep_week[:friday]
+      context[:stabilization_week_start] = stabilization_week[:monday]
+      context[:stabilization_week_end] = stabilization_week[:friday]
     end
     opts.on('--owner [OWNER]', "The release owner's username on Discourse") do |t|
       owner = discourse_username(t)

--- a/procedures/foreman/branch.md.erb
+++ b/procedures/foreman/branch.md.erb
@@ -4,7 +4,7 @@
 * Release Engineer: <%= engineer %>
 * Installer Maintainer: @
 
-# Prep Week: <%= two_weeks_before %> to <%= two_weeks_before + 4 %>
+# Prep Week: <%= prep_week_start %> to <%= prep_week_end %>
 
 ## Installer Maintainer
 
@@ -40,7 +40,7 @@
   - [ ] Track translation work in project management:
     - [ ] Create Redmine issue for locale updates: [Template link](https://projects.theforeman.org/projects/foreman/issues/new?issue[description]=Update%20locales%20for%20Foreman%20<%= release %>%20release&issue[tracker_id]=2&issue[subject]=Update%20locales%20for%20<%= release %>&issue[category_id]=57&issue[custom_field_values][5]=1)
 
-# Stabilization Week: <%= one_week_before %> to <%= one_week_before + 4 %>
+# Stabilization Week: <%= stabilization_week_start %> to <%= stabilization_week_end %>
 
 ## Release Owner
 

--- a/procedures/katello/branch.md.erb
+++ b/procedures/katello/branch.md.erb
@@ -27,7 +27,7 @@
 
 - [ ] Ensure that issues requiring installer changes are merged
 
-# Prep week: <%= two_weeks_before %> to <%= two_weeks_before + 4 %>
+# Prep week: <%= prep_week_start %> to <%= prep_week_end %>
 
 ## Release Owner
 

--- a/schedule
+++ b/schedule
@@ -33,6 +33,9 @@ def week_range(day: date) -> str:
     """
     Accept a date and show the Monday - Friday dates in that week.
 
+    NOTE: This logic is duplicated in procedure script (Ruby version)
+    If you change this, update procedure:week_range() to match
+
     >>> week_range(date(2024, 3, 1))
     '2024-2-26 - 2024-3-1'
     """


### PR DESCRIPTION
Calculate week ranges correctly as Monday-Friday
    
Update Foreman and Katello branch templates to use calculated week
ranges (prep_week_start/end, stabilization_week_start/end) instead of
incorrect date arithmetic (two_weeks_before + 4).
    
Add cross-reference comments between schedule and procedure scripts
to prevent future divergence of the duplicated logic.

#### Note
requires #548
