### PR TITLE
Add require_gpg_key() to validate GPG prerequisites automatically

### DIFF
--- a/export_gpg_private
+++ b/export_gpg_private
@@ -2,16 +2,7 @@
 
 . settings
 
-if [[ ! -d $KEYDIR ]] ; then
-	echo "Keydir $KEYDIR doesn't exist"
-	exit 1
-fi
-
-if [[ -z $FULLGPGKEY ]] ; then
-	echo "FULLGPGKEY must be set"
-	gpg2 --homedir "$KEYDIR" --list-key "$SIGNER"
-	exit 2
-fi
+require_gpg_key
 
 # Verify key has no third-party signatures
 ./verify_gpg_clean || exit $?

--- a/export_gpg_public
+++ b/export_gpg_public
@@ -2,16 +2,7 @@
 
 . settings
 
-if [[ ! -d $KEYDIR ]] ; then
-	echo "Keydir $KEYDIR doesn't exist"
-	exit 1
-fi
-
-if [[ -z $FULLGPGKEY ]] ; then
-	echo "FULLGPGKEY must be set"
-	gpg2 --homedir "$KEYDIR" --list-key "$SIGNER"
-	exit 2
-fi
+require_gpg_key
 
 # Verify key has no third-party signatures
 ./verify_gpg_clean || exit $?

--- a/settings
+++ b/settings
@@ -116,6 +116,23 @@ require_fullversion() {
 	fi
 }
 
+require_gpg_key() {
+	if [[ ! -d "$KEYDIR" ]] ; then
+		echo "GPG keyring directory not found: $KEYDIR" >&2
+		exit 1
+	fi
+
+	if [[ -z "$FULLGPGKEY" ]] ; then
+		echo "FULLGPGKEY not set in $RELEASEDIR/settings" >&2
+		exit 2
+	fi
+
+	if ! gpg2 --homedir "$KEYDIR" --list-keys "$FULLGPGKEY" &>/dev/null ; then
+		echo "GPG key $FULLGPGKEY not found in keyring at $KEYDIR" >&2
+		exit 1
+	fi
+}
+
 # Function to construct GitHub URLs based on protocol
 github_url() {
     local repo="$1"

--- a/sign_gpg
+++ b/sign_gpg
@@ -2,16 +2,7 @@
 
 . settings
 
-if [[ ! -d $KEYDIR ]] ; then
-	echo "Keydir $KEYDIR doesn't exist"
-	exit 1
-fi
-
-if [[ -z $FULLGPGKEY ]] ; then
-	echo "FULLGPGKEY must be set"
-	gpg2 --homedir "$KEYDIR" --list-keys "$VERSION"
-	exit 2
-fi
+require_gpg_key
 
 gpg2 --homedir "$KEYDIR" --armor --export "$FULLGPGKEY" | gpg2 --import
 

--- a/sign_rpms
+++ b/sign_rpms
@@ -2,6 +2,8 @@
 
 . settings
 
+require_gpg_key
+
 gpg_pass=$(mktemp)
 trap 'shred --remove "${gpg_pass}"' EXIT
 chmod 0700 "$gpg_pass"

--- a/sign_stage_rpms
+++ b/sign_stage_rpms
@@ -4,6 +4,8 @@ set -e
 
 . settings
 
+require_gpg_key
+
 for os in $OSES; do
   for arch in $ARCHES; do
     UNSIGNED_RPMS=$(./list_unsigned_rpms "$STAGE_LOCAL_BASE/$os/$arch" "$HALFGPGKEY")

--- a/sign_tarballs
+++ b/sign_tarballs
@@ -3,6 +3,7 @@
 . settings
 
 require_fullversion
+require_gpg_key
 
 sign() {
 	for project in $TAR_PROJECTS ; do

--- a/upload_gpg
+++ b/upload_gpg
@@ -2,14 +2,6 @@
 
 . settings
 
-if [[ ! -d $KEYDIR ]] ; then
-	echo "Keydir $KEYDIR doesn't exist"
-	exit 1
-fi
-
-if [[ -z $FULLGPGKEY ]] ; then
-	echo "FULLGPGKEY is not set"
-	exit 2
-fi
+require_gpg_key
 
 gpg2 --keyserver pgp.mit.edu --send-keys "$FULLGPGKEY"

--- a/upload_yum_gpg
+++ b/upload_yum_gpg
@@ -2,15 +2,7 @@
 
 . settings
 
-if [[ ! -d $KEYDIR ]] ; then
-	echo "Keydir $KEYDIR doesn't exist"
-	exit 1
-fi
-
-if [[ -z $FULLGPGKEY ]] ; then
-	echo "FULLGPGKEY is not set"
-	exit 2
-fi
+require_gpg_key
 
 upload() {
 	local gpg_key


### PR DESCRIPTION
Supersedes #546
This implements the proper solution suggested by @ekohl in the review of PR #546.

## Problem

Scripts that require GPG keys can fail cryptically if:
- The GPG keyring directory (KEYDIR) doesn't exist
- The FULLGPGKEY is not set in release settings
- The expected key is not imported in the keyring

Previously, this required manual checklist compliance ("remember to import the key first").

## Solution

Add `require_gpg_key()` helper function in `settings` that:
1. Verifies KEYDIR exists
2. Verifies FULLGPGKEY is set
3. Verifies the specific release key exists in the keyring

Update all scripts that require GPG keys to call `require_gpg_key()` at startup.

## Benefits

- Fail fast
- Consistent error handling
- Self-documenting

## Testing

Tested all error scenarios:
- Missing KEYDIR: Clear error message
- Missing FULLGPGKEY: Clear error message
- Key not in keyring: Clear error message
- Valid configuration: Script proceeds normally"
