### PR TITLE
Fix transifex_announcement argument name

### DIFF
--- a/transifex_announcement
+++ b/transifex_announcement
@@ -3,7 +3,7 @@
 require 'date'
 
 if ARGV.length != 3
-  puts "Usage: #{$0} <ga_date> <schedule_url> <planning_url>"
+  puts "Usage: #{$0} <ga_date> <schedule_url> <translations_state_url>"
   puts "Example: VERSION=3.16 #{$0} 2025-09-09 'https://community.theforeman.org/t/foreman-3-16-schedule-and-planning/43345' 'https://community.theforeman.org/t/string-freeze-and-state-of-translations-foreman-3-16/44042'"
   exit 1
 end
@@ -16,7 +16,7 @@ end
 
 ga_date = ARGV[0]
 schedule_url = ARGV[1]
-planning_url = ARGV[2]
+translations_state_url = ARGV[2]
 
 # Validate date format
 begin
@@ -33,7 +33,7 @@ Hello,
 
 We are in the process of branching for the #{version} release and extracting strings. We will be pulling in new translations before each new release candidate (RC), and #{version} is expected to GA by #{ga_date}. Plugin strings will also be revised in the coming weeks.
 
-The schedule of #{version} is available at: #{schedule_url}. State of translations is available here: #{planning_url}
+The schedule of #{version} is available at: #{schedule_url}. State of translations is available here: #{translations_state_url}
 
 If you wish to coordinate or require assistance, you are welcome to comment on https://community.theforeman.org or find us on [#theforeman-dev on matrix.org](https://matrix.to/#/#theforeman-dev:matrix.org).
 


### PR DESCRIPTION
Change `planning_url` to `translations_state_url` to accurately reflect the argument's purpose in the announcement text.

The third argument is used for the state of translations URL, not a planning URL.