### PR TITLE
Support candlepin in release procedure

### DIFF
--- a/procedure
+++ b/procedure
@@ -109,7 +109,7 @@ procedures = {
     end
 	end,
 	'release' => OptionParser.new do |opts|
-    opts.on('--project [PROJECT]', ['foreman', 'katello'],
+    opts.on('--project [PROJECT]', ['foreman', 'katello', 'candlepin'],
             'Project to generate release procedure for') do |project|
       context[:project] = project
     end
@@ -155,7 +155,7 @@ procedures = {
 def missing_required_option?(procedure, context)
   case context[:project]
   when 'candlepin'
-    context[:release].nil?
+    context[:release].nil? && context[:short_version].nil?
   when 'katello'
     context[:target_date].nil? || context[:owner].nil? || (procedure == 'release' && context[:foreman_version].nil?)
   when 'foreman'

--- a/procedure
+++ b/procedure
@@ -155,7 +155,12 @@ procedures = {
 def missing_required_option?(procedure, context)
   case context[:project]
   when 'candlepin'
-    context[:release].nil? && context[:short_version].nil?
+    case procedure
+    when 'branch'
+      context[:release].nil?
+    when 'release'
+      context[:version].nil?
+    end
   when 'katello'
     context[:target_date].nil? || context[:owner].nil? || (procedure == 'release' && context[:foreman_version].nil?)
   when 'foreman'

--- a/procedure_release
+++ b/procedure_release
@@ -24,4 +24,9 @@ if [[ $READ == 1 ]] ; then
 	echo >&2
 fi
 
-./procedure release --project "$PROJECT" --version "$FULLVERSION" --foreman-version "$FOREMAN_VERSION" --target-date "$TARGET_DATE" --owner "$OWNER" --engineer "$ENGINEER"
+FOREMAN_VERSION_ARGS=()
+if [[ -n "$FOREMAN_VERSION" && "$FOREMAN_VERSION" != "none" ]]; then
+	FOREMAN_VERSION_ARGS=(--foreman-version "$FOREMAN_VERSION")
+fi
+
+./procedure release --project "$PROJECT" --version "$FULLVERSION" "${FOREMAN_VERSION_ARGS[@]}" --target-date "$TARGET_DATE" --owner "$OWNER" --engineer "$ENGINEER"

--- a/procedures/candlepin/release.md.erb
+++ b/procedures/candlepin/release.md.erb
@@ -7,3 +7,4 @@
   - [ ] <%= rel_eng_script('sign_stage_rpms') %>: `VERSION=<%= short_version %> PROJECT=candlepin ./sign_stage_rpms`
   - [ ] <%= rel_eng_script('upload_stage_rpms') %>: `VERSION=<%= short_version %> PROJECT=candlepin ./upload_stage_rpms`
 - [ ] Kick off the [release pipeline](https://ci.theforeman.org/job/candlepin-<%= short_version %>-rpm-pipeline/) by calling <%= rel_eng_script('release_pipeline') %>: `VERSION=<%= short_version %> PROJECT=candlepin ./release_pipeline`
+- [ ] Announce the release on [Discourse](https://community.theforeman.org/c/release-announcements/8) using <%= rel_eng_script('release_announcement') %>: `FULLVERSION=<%= version %> VERSION=<%= short_version %> PROJECT=candlepin ./release_announcement`

--- a/procedures/candlepin/release.md.erb
+++ b/procedures/candlepin/release.md.erb
@@ -1,7 +1,7 @@
 # Build Package
 
-- [ ] Acquire Candlepin SRPM for <%= short_version %>
-- [ ] Build into Copr: `copr build @theforeman/candlepin-<%= short_version %>-staging <SRPM>`
+- [ ] Acquire Candlepin SRPM for <%= version %>
+- [ ] Build into Copr: `copr build @theforeman/candlepin-<%= short_version %>-staging candlepin-<%= full_version %>*.src.rpm`
 - [ ] Sign RPMs
   - [ ] <%= rel_eng_script('generate_stage_repository') %>: `VERSION=<%= short_version %> PROJECT=candlepin ./generate_stage_repository`
   - [ ] <%= rel_eng_script('sign_stage_rpms') %>: `VERSION=<%= short_version %> PROJECT=candlepin ./sign_stage_rpms`

--- a/procedures/candlepin/release.md.erb
+++ b/procedures/candlepin/release.md.erb
@@ -1,9 +1,9 @@
 # Build Package
 
-- [ ] Acquire Candlepin SRPM for <%= release %>
-- [ ] Build into Copr: `copr build @theforeman/candlepin-staging-<%= release %> <SRPM>`
+- [ ] Acquire Candlepin SRPM for <%= short_version %>
+- [ ] Build into Copr: `copr build @theforeman/candlepin-<%= short_version %>-staging <SRPM>`
 - [ ] Sign RPMs
-  - [ ] <%= rel_eng_script('generate_stage_repository') %>: `VERSION=<%= release %> PROJECT=candlepin ./generate_stage_repository`
-  - [ ] <%= rel_eng_script('sign_stage_rpms') %>: `VERSION=<%= release %> PROJECT=candlepin ./sign_stage_rpms`
-  - [ ] <%= rel_eng_script('upload_stage_rpms') %>: `VERSION=<%= release %> PROJECT=candlepin ./upload_stage_rpms`
-- [ ] Kick off the [release pipeline](https://ci.theforeman.org/job/candlepin-<%= release %>-rpm-pipeline/) by calling <%= rel_eng_script('release_pipeline') %>: `VERSION=<%= release %> PROJECT=candlepin ./release_pipeline`
+  - [ ] <%= rel_eng_script('generate_stage_repository') %>: `VERSION=<%= short_version %> PROJECT=candlepin ./generate_stage_repository`
+  - [ ] <%= rel_eng_script('sign_stage_rpms') %>: `VERSION=<%= short_version %> PROJECT=candlepin ./sign_stage_rpms`
+  - [ ] <%= rel_eng_script('upload_stage_rpms') %>: `VERSION=<%= short_version %> PROJECT=candlepin ./upload_stage_rpms`
+- [ ] Kick off the [release pipeline](https://ci.theforeman.org/job/candlepin-<%= short_version %>-rpm-pipeline/) by calling <%= rel_eng_script('release_pipeline') %>: `VERSION=<%= short_version %> PROJECT=candlepin ./release_pipeline`

--- a/release_announcement
+++ b/release_announcement
@@ -14,7 +14,14 @@ else
 fi
 echo >> "$ANNOUNCEMENT"
 
-if [[ $PROJECT == foreman ]] ; then
+if [[ $PROJECT == candlepin ]] ; then
+	cat >> "$ANNOUNCEMENT" <<-EOF
+	Packages may be found at [yum.theforeman.org/candlepin/${VERSION}/](https://yum.theforeman.org/candlepin/${VERSION}/).
+
+	The GPG key used for signing RPMs has the following fingerprint:
+	[${FULLGPGKEY}](https://theforeman.org/static/keys/${FULLGPGKEY}.pub)
+	EOF
+elif [[ $PROJECT == foreman ]] ; then
 	echo Enter the announcement text, end by CTRL+D: >&2
 	cat >> "$ANNOUNCEMENT"
 


### PR DESCRIPTION
Add candlepin to the allowed project list for the release subcommand,
skip --foreman-version when not applicable, and fix the Copr repo name
in the candlepin release template.
