### PR TITLE
Create a develop tag when starting development

### DIFF
--- a/develop_branch_bump
+++ b/develop_branch_bump
@@ -5,6 +5,7 @@
 MAJOR=${VERSION%.*}
 MINOR=${VERSION#*.}
 DEVELOP=${MAJOR}.$((MINOR + 1))
+DEVELOP_VERSION="${DEVELOP}.0-develop"
 
 for project in $(./ensure_clean_git_checkouts "$@") ; do
 	(
@@ -24,6 +25,7 @@ for project in $(./ensure_clean_git_checkouts "$@") ; do
 			git add package.json
 		fi
 
-		git commit --message "Bump ${GIT_DEVELOP_BRANCH} to ${DEVELOP}.0-develop"
+		git commit --message "Bump ${GIT_DEVELOP_BRANCH} to ${DEVELOP_VERSION}"
+		git tag --message "Start ${DEVELOP} development" "${DEVELOP_VERSION}"
 	)
 done

--- a/develop_branch_push
+++ b/develop_branch_push
@@ -6,6 +6,6 @@ for project in $(./ensure_clean_git_checkouts "$@") ; do
 	(
 		cd "$GIT_DIR/$project"
 		echo "Pushing ${project} $GIT_DEVELOP_BRANCH"
-		git push "${GIT_REMOTE}" "$GIT_DEVELOP_BRANCH"
+		git push --follow-tags "${GIT_REMOTE}" "$GIT_DEVELOP_BRANCH"
 	)
 done


### PR DESCRIPTION
Having a tag on branching makes git describe more useful. Right now it's rather useless, like in foreman on current develop:

```console
$ git describe
0.1-11062-g020f7d9848cc
```

After this it becomes:

```console
$ git describe
5.0.0-develop-7-g020f7d9848cc
```

Disclaimer: I have not tested this.