### PR TITLE
Candlepin 4.8 settings

### DIFF
--- a/releases/candlepin/4.8/settings
+++ b/releases/candlepin/4.8/settings
@@ -1,0 +1,1 @@
+FULLGPGKEY=''


### PR DESCRIPTION
## Summary
- Add release settings directory for Candlepin 4.8
- GPG key will be populated after running `generate_gpg`

## Context
- Tracked by [SAT-45757](https://redhat.atlassian.net/browse/SAT-45757)
- Candlepin 4.8 SRPM already built in Brew (taskID 70721757)
- Includes PQC support (prerequisite for SAT-35691)

🤖 Generated with [Claude Code](https://claude.com/claude-code)