### PR TITLE
Update repoclosure yum.conf during candlepin branching

### DIFF
--- a/branch_project
+++ b/branch_project
@@ -21,7 +21,8 @@ for repo in $(./ensure_clean_git_checkouts "$@") ; do
 			git commit --message "Pin Puppet modules for ${VERSION}"
 		elif [[ $repo == candlepin-packaging ]] ; then
 			sed -i "/candlepin_version/ s/'.\+'/'$VERSION'/" package_manifest.yaml
-			git add package_manifest.yaml
+			sed -i "s/candlepin-nightly-staging/candlepin-${VERSION}-staging/g; s|/candlepin/nightly/|/candlepin/${VERSION}/|g; s/Candlepin nightly staging/Candlepin ${VERSION} staging/g" repoclosure/yum.conf
+			git add package_manifest.yaml repoclosure/yum.conf
 			git commit --message "Set Candlepin version to ${VERSION}"
 		fi
 	)

--- a/procedures/candlepin/branch.md.erb
+++ b/procedures/candlepin/branch.md.erb
@@ -10,4 +10,5 @@
   - [ ] <%= rel_eng_script('sign_gpg') %>: `VERSION=<%= release %> PROJECT=candlepin ./sign_gpg`
   - [ ] <%= rel_eng_script('upload_gpg') %>: `VERSION=<%= release %> PROJECT=candlepin ./upload_gpg`
   - Update `releases/candlepin/<%= release %>/settings` and submit as a PR to [theforeman-rel-eng](https://github.com/theforeman/theforeman-rel-eng)
-- Backport GPG key to stable/branched Katello branches. Identify which stable Katello branches (rpm/x.y in foreman-packaging) will use Candlepin <%= release %>
+- [ ] Update [foreman-packaging](https://github.com/theforeman/foreman-packaging) rpm/develop with the new GPG key and Candlepin version in `katello-repos` (candlepin.gpg, katello-repos.spec)
+- [ ] Backport GPG key and version to stable Katello branches (rpm/x.y) as they are ready to adopt Candlepin <%= release %>


### PR DESCRIPTION
## Summary
- Fix `branch_project` to also update `repoclosure/yum.conf` when branching candlepin-packaging
- Replaces `nightly` with the version number in repo IDs, baseurls, and repo names
- Without this, the release pipeline's repoclosure stage fails with `Unknown repo: el9-candlepin-X.Y-staging` because yum.conf still references `el9-candlepin-nightly-staging`

Found during the Candlepin 4.8 release — had to fix `rpm/4.8` manually after the pipeline failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)