### PR TITLE
Add foreman-documentation and forklift steps to candlepin branch procedure

### DIFF
--- a/procedures/candlepin/branch.md.erb
+++ b/procedures/candlepin/branch.md.erb
@@ -12,3 +12,5 @@
   - Update `releases/candlepin/<%= release %>/settings` and submit as a PR to [theforeman-rel-eng](https://github.com/theforeman/theforeman-rel-eng)
 - [ ] Update [foreman-packaging](https://github.com/theforeman/foreman-packaging) rpm/develop with the new GPG key and Candlepin version in `katello-repos` (candlepin.gpg, katello-repos.spec)
 - [ ] Backport GPG key and version to stable Katello branches (rpm/x.y) as they are ready to adopt Candlepin <%= release %>
+- [ ] Update [foreman-documentation](https://github.com/theforeman/foreman-documentation): set `:CandlepinVersion:` to `<%= release %>` in `guides/common/attributes.adoc`
+- [ ] Update [forklift](https://github.com/theforeman/forklift): set `candlepin:` to `'<%= release %>'` for the nightly entry in `vagrant/config/versions.yaml`


### PR DESCRIPTION
## Summary
- Add checklist items for updating foreman-documentation (`:CandlepinVersion:` attribute) and forklift (`candlepin:` version in versions.yaml) when branching a new Candlepin release
- These were missed during the Candlepin 4.8 release and had to be done separately

Examples from 4.8:
- https://github.com/theforeman/foreman-documentation/pull/4970
- https://github.com/theforeman/forklift/pull/1957

🤖 Generated with [Claude Code](https://claude.com/claude-code)