### PR TITLE
Add next-patch mode to create_redmine_version

### DIFF
--- a/create_redmine_version
+++ b/create_redmine_version
@@ -4,8 +4,21 @@
 
 require_fullversion
 
+MODE="$1"
+if [[ -n $MODE && $MODE != next ]] ; then
+	echo "Usage: $0 [next]" >&2
+	exit 1
+fi
+
 # Strip any -rc or other suffix from FULLVERSION to get base version (e.g., 3.18.0-rc1 -> 3.18.0)
 VERSION_NAME="${FULLVERSION%%-*}"
+
+if [[ $MODE == next ]] ; then
+	# FULLVERSION holds the version being released for (e.g. 3.19.1), not the
+	# one being prepared next, so bump the patch component (-> 3.19.2).
+	IFS=. read -r MAJOR MINOR PATCH <<< "$VERSION_NAME"
+	VERSION_NAME="${MAJOR}.${MINOR}.$((PATCH + 1))"
+fi
 
 # Katello uses 'Katello x.y.z' format in Redmine instead of just 'x.y.z'
 if [[ $PROJECT == katello ]]; then

--- a/procedures/foreman/release.md.erb
+++ b/procedures/foreman/release.md.erb
@@ -38,7 +38,7 @@
 <% unless is_rc -%>
 - Update Redmine versions
   - [ ] Close old <%= short_version %>.x versions using <%= rel_eng_script('close_redmine_version') %>
-  - [ ] Create new version <%= next_patch_version %><%= ' (unless the series is EOL)' unless is_first_ga %> using <%= rel_eng_script('create_redmine_version') %>
+  - [ ] Create new version <%= next_patch_version %><%= ' (unless the series is EOL)' unless is_first_ga %> using <%= rel_eng_script('create_redmine_version') %>: `./create_redmine_version next`
 <% end -%>
 - [ ] Run the Jenkins [Tarballs Release](https://ci.theforeman.org/job/tarballs-release/) using <%= rel_eng_script('release_tarballs') %> to create tarballs
 


### PR DESCRIPTION
## Summary
- `create_redmine_version` stripped the `-rc` suffix from `FULLVERSION` to derive the Redmine version name. Correct for branching (creates `develop.0`), wrong for the "create new version" step after a release is tagged, since `FULLVERSION` still holds the version just released (e.g. `3.19.1`), not the upcoming patch (`3.19.2`).
- Add a `next` argument: bumps the patch component instead of using `FULLVERSION` as-is.
- Update `procedures/foreman/release.md.erb` so the generated release procedure invokes `./create_redmine_version next` for that step.
- Branching procedure (`branch.md.erb`) is unaffected — it still uses the default mode.

## Test plan
- [x] `bash -n create_redmine_version` — syntax OK
- [x] Verified patch-bump math: `3.19.1` → `3.19.2`, `3.19.0` → `3.19.1`
- [x] Verified default mode unchanged: `3.20.0-rc1` → `3.20.0`
- [x] Bad argument produces usage error
- [x] Rendered `./procedure release` for a mid-series patch (`3.19.2`) and first-GA (`3.20.0`) — both correctly show `./create_redmine_version next` with the right target version and EOL caveat only where expected
- [x] Rendered an RC (`3.20.0-rc1`) — confirmed "Update Redmine versions" section is skipped entirely (unchanged, pre-existing `unless is_rc` guard)