### PR TITLE
Fix develop_branch_bump to stage katello version.rb

### DIFF
--- a/develop_branch_bump
+++ b/develop_branch_bump
@@ -14,6 +14,7 @@ for project in $(./ensure_clean_git_checkouts "$@") ; do
 
 		if [[ $project == katello ]] ; then
 			sed -i '/VERSION/ s/[0-9]\+\.[0-9]\+\.[0-9]\+/'"${DEVELOP}".0'/' lib/katello/version.rb
+			git add lib/katello/version.rb
 		else
 			echo "${DEVELOP}.0-develop" > VERSION
 			git add VERSION


### PR DESCRIPTION
## Summary
- Add missing `git add lib/katello/version.rb` in the katello branch of develop_branch_bump
- Without this, the sed modifies the file but the commit fails with nothing staged

🤖 Generated with [Claude Code](https://claude.com/claude-code)