### PR TITLE
Pin Foreman's CI to stable branches on branching

### DIFF
--- a/branch_project
+++ b/branch_project
@@ -19,6 +19,20 @@ for repo in $(./ensure_clean_git_checkouts "$@") ; do
 			bundle exec librarian-puppet install
 			git add .gitignore Puppetfile*
 			git commit --message "Pin Puppet modules for ${VERSION}"
+		elif [[ $repo == foreman ]] ; then
+			# TODO: We don't know the Katello version at this point
+			read -p "Katello version: " -r KATELLO
+			if [[ -z $KATELLO ]] ; then
+				echo "No Katello version given" >&2
+				exit 1
+			fi
+			sed -i "/plugin_repository/a\      plugin_version: KATELLO-$KATELLO" .github/workflows/foreman.yml
+			git add .github/workflows/foreman.yml
+
+			sed -i "s/nightly/$VERSION/" .packit.yaml
+			git add .packit.yaml
+
+			git commit --message "Adjust CI to use $VERSION stable branches"
 		elif [[ $repo == candlepin-packaging ]] ; then
 			sed -i "/candlepin_version/ s/'.\+'/'$VERSION'/" package_manifest.yaml
 			sed -i "s/candlepin-nightly-staging/candlepin-${VERSION}-staging/g; s|/candlepin/nightly/|/candlepin/${VERSION}/|g; s/Candlepin nightly staging/Candlepin ${VERSION} staging/g" repoclosure/yum.conf

--- a/branch_project
+++ b/branch_project
@@ -20,19 +20,12 @@ for repo in $(./ensure_clean_git_checkouts "$@") ; do
 			git add .gitignore Puppetfile*
 			git commit --message "Pin Puppet modules for ${VERSION}"
 		elif [[ $repo == foreman ]] ; then
-			# TODO: We don't know the Katello version at this point
-			read -p "Katello version: " -r KATELLO
-			if [[ -z $KATELLO ]] ; then
-				echo "No Katello version given" >&2
-				exit 1
-			fi
-			sed -i "/plugin_repository/a\      plugin_version: KATELLO-$KATELLO" .github/workflows/foreman.yml
-			git add .github/workflows/foreman.yml
-
-			sed -i "s/nightly/$VERSION/" .packit.yaml
-			git add .packit.yaml
-
-			git commit --message "Adjust CI to use $VERSION stable branches"
+			# Foreman and Katello share the same X.Y version number, so the
+			# stable branch's Katello test dependency is pinned to $VERSION too.
+			sed -i "/plugin_repository/a\      plugin_version: KATELLO-$VERSION" .github/workflows/foreman.yml
+			sed -i "s/nightly/$VERSION/; /rpm\/develop/ s/develop/$VERSION/" .packit.yaml
+			git add .github/workflows/foreman.yml .packit.yaml
+			git commit --message "Pin CI to ${VERSION} stable branches"
 		elif [[ $repo == candlepin-packaging ]] ; then
 			sed -i "/candlepin_version/ s/'.\+'/'$VERSION'/" package_manifest.yaml
 			sed -i "s/candlepin-nightly-staging/candlepin-${VERSION}-staging/g; s|/candlepin/nightly/|/candlepin/${VERSION}/|g; s/Candlepin nightly staging/Candlepin ${VERSION} staging/g" repoclosure/yum.conf


### PR DESCRIPTION
Pins Foreman's stable-branch CI to itself instead of develop/nightly:
- #583: pin the Katello version used in `foreman.yml`'s test job
- #584: update `.packit.yaml` on branching, like Katello already does

Builds on #447 (kept as a separate commit, credited to @ekohl). Since
Foreman and Katello now share the same X.Y version, this drops the
interactive Katello-version prompt in favor of `$VERSION`, and also
fixes the `.packit.yaml` `rpm/develop` wget URLs, which #447 missed
and which caused theforeman/foreman#11003.

Closes #583, closes #584.